### PR TITLE
prevent QuantityType comparison against Numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ here is a non-exhaustive list of significant departures from the original gem:
 * {QuantityType} is no longer implicitly
   convertible and comparable against Strings. Use the `|` operator for easy
   construction of {QuantityType}s: `10 | "°F"`.
+* {QuantityType} can no longer be compared against `Numeric` or {DecimalType} outside
+  a {OpenHAB::DSL.unit unit} block. Either compare it against another QuantityType, or
+  convert it with to_f first, or perform the comparison inside a
+  {OpenHAB::DSL.unit unit} block.
 * The top-level `groups` method providing access to only {GroupItem}s has been
   removed. Use `items.grep(GroupItem)` if you would like to filter to only
   groups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ here is a non-exhaustive list of significant departures from the original gem:
 ### Bug Fixes
 
 * Fix thing {OpenHAB::Core::EntityLookup#method_missing entity lookup}
+* fix `ensure` to work with QuantityType
 
 ## [4.45.2](https://github.com/boc-tothefuture/openhab-jruby/compare/4.45.1...4.45.2) (2022-10-02)
 

--- a/lib/openhab/core/items/numeric_item.rb
+++ b/lib/openhab/core/items/numeric_item.rb
@@ -10,7 +10,11 @@ module OpenHAB
         # raw numbers translate directly to DecimalType, not a string
         # @!visibility private
         def format_type(command)
-          return Types::DecimalType.new(command) if command.is_a?(Numeric)
+          if command.is_a?(Numeric)
+            return Types::QuantityType.new(command, unit) if unit
+
+            return Types::DecimalType.new(command)
+          end
 
           super
         end

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -514,7 +514,7 @@ module OpenHAB
     #   division.
     #
     #   @param [String, javax.measure.Unit] unit Unit or String representing unit
-    #   @yield The block will be executed in the context of the specify unit.
+    #   @yield The block will be executed in the context of the specified unit.
     #
     #   @example
     #     # Number:Temperature NumberC = 23 °C

--- a/spec/openhab/dsl/items/ensure_spec.rb
+++ b/spec/openhab/dsl/items/ensure_spec.rb
@@ -120,12 +120,17 @@ RSpec.describe OpenHAB::DSL::Items::Ensure do
     it "can send a plain number to a NumberItem with a quantity" do
       items.build { number_item "Temp", dimension: "Temperature", format: "%d °F", group: AllItems }
       Temp.update(80)
+      expect(Temp.state).to eq 80 | "°F"
       triggers.clear
       Temp.ensure << 80
       expect(triggers).to be_empty
       Temp.ensure << 50
-      expect(Temp.state).to eq 50
+      expect(Temp.state).to eq 50 | "°F"
+      expect(Temp.state).to eq 10 | "°C"
       expect(triggers).to match_array(both)
+      triggers.clear
+      Temp.ensure << (10 | "°C")
+      expect(triggers).to be_empty
     end
   end
 


### PR DESCRIPTION
Proposed changes so that comparison between QuantityType and String can be supported in a personal library using String#coerce.

The issue was because String responds to `to_d` which prevents QuantityType <=> from calling other.coerce. Furthermore, we should prevent comparison between QuantityType and Numeric because it's ambiguous

Changes in this PR:
```ruby
QuantityType.new("10 °C") == 10                # will raise an exception
unit("°C") { QuantityType.new("10 °C") == 10 } # => true
unit("°F") { QuantityType.new("10 °C") == 50 } # => true
```
