### PR TITLE
add support for DateTime

### DIFF
--- a/docs/usage/misc/time.md
+++ b/docs/usage/misc/time.md
@@ -13,6 +13,7 @@ Several options are available for time related code, including but not limited t
 * Java {Period}
 * Ruby [Date](https://ruby-doc.org/stdlib-2.6.8/libdoc/date/rdoc/Date.html) - represents a date with no time
 * Ruby [Time](https://ruby-doc.org/core/Time.html) - represents a specific instant with a date and time
+* Ruby [DateTime](https://ruby-doc.org/core/DateTime.html) - represents a specific instant with a date and time
 
 ## Durations
 

--- a/lib/openhab/core_ext/ruby/time.rb
+++ b/lib/openhab/core_ext/ruby/time.rb
@@ -1,77 +1,104 @@
 # frozen_string_literal: true
 
-# Extensions to Time
+require "forwardable"
+
+module OpenHAB
+  module CoreExt
+    module Ruby
+      # Extensions to Time and DateTime
+      module TimeExtensions
+        extend Forwardable
+
+        # @!visibility private
+        def self.included(base)
+          base.send :alias_method, :plus_without_temporal, :+
+          base.send :alias_method, :+, :plus_with_temporal
+          base.send :alias_method, :minus_without_temporal, :-
+          base.send :alias_method, :-, :minus_with_temporal
+        end
+
+        #
+        # @!method +(other)
+        #
+        # Extends {#+} to allow adding a {java.time.temporal.TemporalAmount TemporalAmount}
+        #
+        # @param [java.time.temporal.TemporalAmount] other
+        # @return [ZonedDateTime] If other is a {java.time.temporal.TemporalAmount TemporalAmount}
+        # @return [Time] If other is a Numeric
+        #
+        def plus_with_temporal(other)
+          return to_zoned_date_time + other if other.is_a?(java.time.temporal.TemporalAmount)
+
+          plus_without_temporal(other)
+        end
+
+        #
+        # @!method -(other)
+        #
+        # Extends {#-} to allow subtracting a {java.time.temporal.TemporalAmount TemporalAmount}
+        #
+        # @param [java.time.temporal.TemporalAmount] other
+        # @return [ZonedDateTime] If other is a {java.time.temporal.TemporalAmount TemporalAmount}
+        # @return [Time] If other is a Numeric
+        #
+        def minus_with_temporal(other)
+          return to_zoned_date_time - other if other.is_a?(java.time.temporal.TemporalAmount)
+
+          minus_without_temporal(other)
+        end
+
+        # @return [LocalDate]
+        def to_local_date(_context = nil)
+          java.time.LocalDate.of(year, month, day)
+        end
+
+        # @!method to_local_time
+        #   @return [LocalTime]
+        def_delegator :to_zoned_date_time, :to_local_time
+
+        # @return [Month]
+        def to_month
+          java.time.Month.of(month)
+        end
+
+        # @return [MonthDay]
+        def to_month_day
+          java.time.MonthDay.of(month, day)
+        end
+
+        # @param [ZonedDateTime, nil] context
+        #   A {ZonedDateTime} used to fill in missing fields
+        #   during conversion. Not used in this class.
+        # @return [ZonedDateTime]
+        def to_zoned_date_time(_context = nil)
+          to_java(ZonedDateTime)
+        end
+
+        #
+        # Converts to a {ZonedDateTime} if `other`
+        # is also convertible to a ZonedDateTime.
+        #
+        # @param [#to_zoned_date_time] other
+        # @return [Array, nil]
+        #
+        def coerce(other)
+          [other.to_zoned_date_time(to_zoned_date_time), self] if other.respond_to?(:to_zoned_date_time)
+        end
+      end
+    end
+  end
+end
+
+#
+# Extensions to Ruby Time
+#
 class Time
-  #
-  # @!method +(other)
-  #
-  # Extends {#+} to allow adding a {java.time.temporal.TemporalAmount TemporalAmount}
-  #
-  # @param [java.time.temporal.TemporalAmount] other
-  # @return [ZonedDateTime] If other is a {java.time.temporal.TemporalAmount TemporalAmount}
-  # @return [Time] If other is a Numeric
-  #
-  def plus_with_temporal(other)
-    return to_zoned_date_time + other if other.is_a?(java.time.temporal.TemporalAmount)
+  include(OpenHAB::CoreExt::Ruby::TimeExtensions)
+end
 
-    plus_without_temporal(other)
-  end
-  alias_method :plus_without_temporal, :+
-  alias_method :+, :plus_with_temporal
-
-  #
-  # @!method -(other)
-  #
-  # Extends {#-} to allow subtracting a {java.time.temporal.TemporalAmount TemporalAmount}
-  #
-  # @param [java.time.temporal.TemporalAmount] other
-  # @return [ZonedDateTime] If other is a {java.time.temporal.TemporalAmount TemporalAmount}
-  # @return [Time] If other is a Numeric
-  #
-  def minus_with_temporal(other)
-    return to_zoned_date_time - other if other.is_a?(java.time.temporal.TemporalAmount)
-
-    minus_without_temporal(other)
-  end
-  alias_method :minus_without_temporal, :-
-  alias_method :-, :minus_with_temporal
-
-  # @return [LocalDate]
-  def to_local_date(_context = nil)
-    java.time.LocalDate.of(year, month, day)
-  end
-
-  # @return [LocalTime]
-  def to_local_time
-    java.time.LocalTime.of(hour, min, sec, nsec)
-  end
-
-  # @return [Month]
-  def to_month
-    java.time.Month.of(month)
-  end
-
-  # @return [MonthDay]
-  def to_month_day
-    java.time.MonthDay.of(month, day)
-  end
-
-  # @param [ZonedDateTime, nil] context
-  #   A {ZonedDateTime} used to fill in missing fields
-  #   during conversion. Not used in this class.
-  # @return [ZonedDateTime]
-  def to_zoned_date_time(_context = nil)
-    to_java(ZonedDateTime)
-  end
-
-  #
-  # Converts to a {ZonedDateTime} if `other`
-  # is also convertible to a ZonedDateTime.
-  #
-  # @param [#to_zoned_date_time] other
-  # @return [Array, nil]
-  #
-  def coerce(other)
-    [other.to_zoned_date_time(to_zoned_date_time), self] if other.respond_to?(:to_zoned_date_time)
-  end
+#
+# Extensions to Ruby DateTime
+#
+class DateTime
+  include(OpenHAB::CoreExt::Ruby::TimeExtensions)
 end


### PR DESCRIPTION
I noticed this spec failing inside month_day_spec

```ruby
    specify { expect((yesterday..tomorrow).cover?(DateTime.now)).to be true }
```

it failed only at a certain DateTime.now.

If this support isn't wanted, we should instead remove the above spec line.