### PR TITLE
remove rubylib special handling

### DIFF
--- a/lib/openhab/core.rb
+++ b/lib/openhab/core.rb
@@ -43,20 +43,6 @@ module OpenHAB
       end
 
       #
-      # JRuby isn't respecting $RUBYLIB when run embedded inside of OpenHAB, so do it manually
-      #
-      # @return [void]
-      #
-      # @!visibility private
-      def add_rubylib_to_load_path
-        ENV["RUBYLIB"]&.split(File::PATH_SEPARATOR)&.each do |path|
-          next if path.empty?
-
-          $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
-        end
-      end
-
-      #
       # @!attribute [r] automation_manager
       # @return [org.openhab.core.automation.module.script.rulesupport.shared.ScriptedAutomationManager]
       #   The OpenHAB Automation manager.

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -675,7 +675,6 @@ module OpenHAB
 end
 
 OpenHAB::Core.wait_till_openhab_ready
-OpenHAB::Core.add_rubylib_to_load_path
 
 # import Items classes into global namespace
 OpenHAB::Core::Items.import_into_global_namespace


### PR DESCRIPTION
This functionality is already included in the openhab 3.3 addon https://github.com/openhab/openhab-addons/pull/12123
