### PR TITLE
fix reentrant timer

### DIFF
--- a/lib/openhab/core/timer.rb
+++ b/lib/openhab/core/timer.rb
@@ -96,6 +96,18 @@ module OpenHAB
       #
       def cancel
         DSL.timers.delete(self)
+        _cancel
+      end
+
+      #
+      # Cancel the timer but not remove self from the timer manager
+      #
+      # To be used internally by {TimerManager} from inside ConcurrentHashMap's compute blocks
+      #
+      # @return [true,false] True if cancel was successful, false otherwise
+      #
+      # @!visibility private
+      def _cancel
         @timer.cancel
       end
 

--- a/lib/openhab/dsl/timer_manager.rb
+++ b/lib/openhab/dsl/timer_manager.rb
@@ -31,7 +31,8 @@ module OpenHAB
             # timer when one doesn't already exist
             next old_timer if !reschedule && old_timer
 
-            old_timer&.cancel
+            old_timer&._cancel
+            @timers.remove(old_timer) if old_timer
             Core::Timer.new(duration, id: id, thread_locals: thread_locals, block: block)
           end
         end
@@ -55,7 +56,7 @@ module OpenHAB
         @timers.remove(timer)
         return unless timer.id
 
-        @timers_by_id.delete(timer.id)
+        @timers_by_id.remove(timer.id)
       end
 
       #
@@ -67,7 +68,9 @@ module OpenHAB
       def cancel(id)
         result = false
         @timers_by_id.compute_if_present(id) do |_key, timer|
-          result = timer.cancel
+          result = timer._cancel
+          @timers.remove(timer)
+
           nil
         end
         result
@@ -136,8 +139,9 @@ module OpenHAB
 
           if timer&.cancelled?
             new_timer = nil
-          elsif new_timer.nil? && !timer&.cancelled?
-            timer&.cancel
+          elsif new_timer.nil? && timer && !timer.cancelled?
+            timer._cancel
+            @timers.remove(timer)
           end
           next unless new_timer
 

--- a/lib/openhab/rspec/mocks/timer.rb
+++ b/lib/openhab/rspec/mocks/timer.rb
@@ -70,8 +70,13 @@ module OpenHAB
           return false if terminated? || cancelled?
 
           DSL::TimerManager.instance.delete(self)
-          @execution_time = nil
+          _cancel
           true
+        end
+
+        def _cancel
+          @execution_time = nil
+          self
         end
 
         def cancelled?

--- a/spec/openhab/core/timer_spec.rb
+++ b/spec/openhab/core/timer_spec.rb
@@ -175,6 +175,18 @@ RSpec.describe OpenHAB::Core::Timer do
         expect(second_executed).to be false
       end
 
+      it "is reentrant" do
+        exec_proofs = []
+        200.step(by: 100, to: 1000) do |delay|
+          after(delay.milliseconds, id: "id") { exec_proofs << delay }
+
+          expect(timers.key?("id")).to be true
+        end
+
+        time_travel_and_execute_timers(1.1.seconds)
+        expect(exec_proofs).to eq [1000]
+      end
+
       describe "TimerManager#schedule" do
         it "requires the block to return a valid timer" do
           proper_timer_class = self.class.mock_timers? ? OpenHAB::RSpec::Mocks::Timer : described_class


### PR DESCRIPTION
Timer#cancel shouldn't be called from inside a compute block because it deletes the timer id from the map being computed

Once it's deleted, the timer is no longer re-entrant, and multiple timers will be created.

On the second call to `after`, the timer id will be deleted from `timers` object. Although the first timer gets cancelled, the second timer is no longer kept track of. On the third call, a new timer is created whilst the second timer remains active, thus violating the reentrancy.