### PR TITLE
use $events, the implicitly imported global

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,7 @@ Style/Documentation:
 Style/GlobalVars:
   AllowedVariables: # these globals are set by OpenHAB, and we can't change their name
    - $actions
+   - $events
    - $ir
    - $rules
    - $se

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -73,7 +73,7 @@ module OpenHAB
         def command(command)
           command = format_command(command)
           logger.trace "Sending Command #{command} to #{name}"
-          org.openhab.core.model.script.actions.BusEvent.sendCommand(self, command)
+          $events.send_command(self, command)
           self
         end
 
@@ -93,7 +93,7 @@ module OpenHAB
         def update(state)
           state = format_update(state)
           logger.trace "Sending Update #{state} to #{name}"
-          org.openhab.core.model.script.actions.BusEvent.postUpdate(self, state)
+          $events.post_update(self, state)
           self
         end
 

--- a/lib/openhab/core/items/state_storage.rb
+++ b/lib/openhab/core/items/state_storage.rb
@@ -18,7 +18,7 @@ module OpenHAB
         #
         # @!visibility private
         def self.from_items(*items)
-          StateStorage.new(org.openhab.core.model.script.actions.BusEvent.store_states(*items).to_h)
+          StateStorage.new($events.store_states(*items).to_h)
         end
 
         #
@@ -27,7 +27,7 @@ module OpenHAB
         # @return [void]
         #
         def restore
-          org.openhab.core.model.script.actions.BusEvent.restore_states(to_h)
+          $events.restore_states(to_h)
         end
 
         #
@@ -36,7 +36,7 @@ module OpenHAB
         # @return [void]
         #
         def restore_changes
-          org.openhab.core.model.script.actions.BusEvent.restore_states(select { |item, value| item.state != value })
+          $events.restore_states(select { |item, value| item.state != value })
         end
 
         #


### PR DESCRIPTION
instead of explicitly referencing the very long class name