### PR TITLE
Support Time - ZonedDateTime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   universal-java-11
+  universal-java-17
   x86_64-darwin-20
   x86_64-linux
 
@@ -212,4 +213,4 @@ DEPENDENCIES
   yard-coderay
 
 BUNDLED WITH
-   2.3.22
+   2.3.25

--- a/docs/usage/misc/time.md
+++ b/docs/usage/misc/time.md
@@ -82,6 +82,11 @@ Motion_Sensor.last_update < Time.now - 10.minutes
 # Alternatively:
 Motion_Sensor.last_update < 10.minutes.ago
 
+# Finding The Duration Between Two Times
+elapsed_time = Time.now - Motion_Sensor.last_update
+# Alternatively:
+elapsed_time = ZonedDateTime.now - Motion_Sensor.last_update
+
 # Using `-` operator with ZonedDateTime
 # Comparing two ZonedDateTime using `<` 
 Motion_Sensor.last_update < Light_Item.last_update - 10.minutes

--- a/lib/openhab/core_ext/java/zoned_date_time.rb
+++ b/lib/openhab/core_ext/java/zoned_date_time.rb
@@ -25,8 +25,7 @@ module OpenHAB
         # @return [ZonedDateTime] If other is a TemporalAmount
         def -(other)
           if other.respond_to?(:to_zoned_date_time)
-            nanos = other.to_zoned_date_time.until(self, java.time.temporal.ChronoUnit::NANOS)
-            (nanos.to_f / 1_000_000_000).seconds
+            java.time.Duration.between(other.to_zoned_date_time, self)
           elsif other.is_a?(Numeric)
             minus(other.seconds)
           else

--- a/lib/openhab/core_ext/ruby/time.rb
+++ b/lib/openhab/core_ext/ruby/time.rb
@@ -36,13 +36,36 @@ module OpenHAB
         # @!method -(other)
         #
         # Extends {#-} to allow subtracting a {java.time.temporal.TemporalAmount TemporalAmount}
+        # or any other date/time class that responds to #to_zoned_date_time.
         #
-        # @param [java.time.temporal.TemporalAmount] other
+        # Subtractions with another object of the same class (e.g. Time - Other Time, or DateTime - Other DateTime)
+        # remains unchanged from its original behavior.
+        #
+        # @example Time - Duration -> ZonedDateTime
+        #   zdt_one_hour_ago = Time.now - 1.hour
+        #
+        # @example Time - ZonedDateTime -> Duration
+        #   java_duration = Time.now - 1.hour.ago
+        #
+        # @example Time - Numeric -> Time
+        #   time_one_hour_ago = Time - 3600
+        #
+        # @example Time - Time -> Float
+        #   one_day_in_secs = Time.new(2002, 10, 31) - Time.new(2002, 10, 30)
+        #
+        # @param [java.time.temporal.TemporalAmount, #to_zoned_date_time] other
         # @return [ZonedDateTime] If other is a {java.time.temporal.TemporalAmount TemporalAmount}
+        # @return [Duration] If other responds to #to_zoned_date_time
         # @return [Time] If other is a Numeric
+        # @return [Float] If other is a Time
         #
         def minus_with_temporal(other)
           return to_zoned_date_time - other if other.is_a?(java.time.temporal.TemporalAmount)
+
+          # Exclude subtracting against the same class
+          if other.respond_to?(:to_zoned_date_time) && !other.is_a?(self.class)
+            return to_zoned_date_time - other.to_zoned_date_time
+          end
 
           minus_without_temporal(other)
         end

--- a/spec/openhab/core_ext/ruby/time_spec.rb
+++ b/spec/openhab/core_ext/ruby/time_spec.rb
@@ -9,9 +9,32 @@ RSpec.describe Time do
   end
 
   describe "#-" do
-    it "works with Duration" do
+    it "works with Duration and returns a ZonedDateTime" do
       now = described_class.now
-      expect(now - 1.minute).to eq(now - 60)
+      result = now - 1.minute
+      expect(result).to eq(now - 60)
+      expect(result).to be_a(java.time.ZonedDateTime)
+    end
+
+    it "works with ZonedDateTime and returns a Duration" do
+      now = described_class.now
+      zdt = now.to_zoned_date_time.minus_minutes(1)
+      result = now - zdt
+      expect(result).to eq(1.minute)
+      expect(result).to be_a(java.time.Duration)
+    end
+
+    it "works with Numeric and returns a Time" do
+      Timecop.freeze
+      result = described_class.now - 60
+      expect(result.to_i).to eq(60.seconds.ago.to_i)
+      expect(result).to be_a(described_class)
+    end
+
+    it "works with another Time and returns a Float" do
+      one_day_in_secs = described_class.new(2002, 10, 31) - described_class.new(2002, 10, 30)
+      expect(one_day_in_secs).to eq(86_400)
+      expect(one_day_in_secs).to be_a(Numeric)
     end
   end
 end


### PR DESCRIPTION
Because ZonedDateTime - Time is already supported. This PR allows the reverse:
Time - ZonedDateTime to also give us a Duration

