### PR TITLE
fix timer id removal after completion

### DIFF
--- a/lib/openhab/core/timer.rb
+++ b/lib/openhab/core/timer.rb
@@ -36,7 +36,6 @@ module OpenHAB
       attr_accessor :id
 
       # @!visibility private
-      # @!visibility private
       attr_reader :block
 
       #
@@ -119,12 +118,8 @@ module OpenHAB
       # @return [void]
       #
       def execute
-        last_execution_time = execution_time
-        DSL::ThreadLocal.thread_local(**@thread_locals) do
-          @block.call(self)
-        end
-        # don't remove ourselves if we were rescheduled in the block
-        DSL.timers.delete(self) if execution_time == last_execution_time
+        DSL.timers.delete(self)
+        DSL::ThreadLocal.thread_local(**@thread_locals) { @block.call(self) }
       end
 
       #

--- a/spec/openhab/core/timer_spec.rb
+++ b/spec/openhab/core/timer_spec.rb
@@ -155,6 +155,15 @@ RSpec.describe OpenHAB::Core::Timer do
         expect(timers).not_to include("id")
       end
 
+      it "removes the timer when finished" do
+        executed = false
+        after(0.1.seconds, id: "id") { executed = true }
+
+        time_travel_and_execute_timers(0.2.seconds)
+        expect(executed).to be true
+        expect(timers).not_to include("id")
+      end
+
       it "can reschedule a timer by id" do
         timer1 = after(5.seconds, id: "id") { nil }
         timer2 = timers.reschedule("id", 1.second)


### PR DESCRIPTION
Timer ids weren't removed from the @timers_by_id hash when the timer completed normally