### PR TITLE
formalize nil return for ensure.command(samestate)

### DIFF
--- a/docs/examples/how_do_i.md
+++ b/docs/examples/how_do_i.md
@@ -74,6 +74,11 @@ My_Item.ensure.command ON
 My_Item.ensure << ON
 ```
 
+```ruby
+# ensure causes the command to return nil if the item is already in the same state
+logger.info("Turning off the light") if My_Item.ensure.off
+```
+
 ### Send a Timed Command
 
 A {OpenHAB::DSL::Items::TimedCommand Timed Command} is similar to the OpenHAB Item's 

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -65,10 +65,17 @@ module OpenHAB
         #
         # Send a command to this item
         #
-        # @param [Command] command command to send to the item
-        # @return [self]
+        # When this method is chained after the {OpenHAB::DSL::Items::Ensure::Ensurable#ensure ensure}
+        # method, or issued inside an {OpenHAB::DSL.ensure_states ensure_states} block,
+        # the command will only be sent if the item is not already in the same state.
         #
-        # @see DSL::Items::TimedCommand#command
+        # @param [Command] command command to send to the item
+        # @return [self, nil] nil when `ensure` is in effect and the item was already in the same state,
+        #   otherwise the item.
+        #
+        # @see DSL::Items::TimedCommand#command Timed Command
+        # @see OpenHAB::DSL.ensure_states ensure_states
+        # @see DSL::Items::Ensure::Ensurable#ensure ensure
         #
         def command(command)
           command = format_command(command)
@@ -88,7 +95,8 @@ module OpenHAB
         # Send an update to this item
         #
         # @param [State] state
-        # @return [self]
+        # @return [self, nil] nil when `ensure` is in effect and the item was already in the same state,
+        #   otherwise the item.
         #
         def update(state)
           state = format_update(state)

--- a/lib/openhab/core/items/semantics/enumerable.rb
+++ b/lib/openhab/core/items/semantics/enumerable.rb
@@ -72,15 +72,17 @@ module Enumerable
   # @!group Items State and Command Methods
 
   # Send a command to every item in the collection
-  # @return [self]
+  # @return [self, nil] nil when `ensure` is in effect and all the items were already in the same state,
+  #   otherwise self
   def command(command)
-    each { |i| i.command(command) }
+    self if count { |i| i.command(command) }.positive?
   end
 
   # Update the state of every item in the collection
-  # @return [self]
+  # @return [self, nil] nil when `ensure` is in effect and all the items were already in the same state,
+  #   otherwise self
   def update(state)
-    each { |i| i.update(state) }
+    self if count { |i| i.update(state) }.positive?
   end
 
   # @!method refresh

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -23,6 +23,9 @@ module OpenHAB
         end
 
         # Extensions for {::GenericItem} to implement {Ensure}'s functionality
+        #
+        # @see OpenHAB::DSL.ensure ensure
+        # @see OpenHAB::DSL.ensure_states ensure_states
         module GenericItem
           include Ensurable
 


### PR DESCRIPTION
ensure.command will return nil when the item
is already in the same state. This applies to #update, and Enumerable