### PR TITLE
add trigger for system startlevel to on_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,9 @@ here is a non-exhaustive list of significant departures from the original gem:
 * {OpenHAB::Core::Items::GenericItem#metadata Metadata} will now be serialized before being set.
   This fixes a complicated issue where types would changed unexpectedly, or even worse, reference Ruby classes that are not even available in the current JRuby instance.
   See https://github.com/openhab/openhab-core/issues/3169 for more details.
+* `#on_start` trigger was renamed to {OpenHAB::DSL::Rules::BuilderDSL#on_load #on_load} and its 'run_on_start' parameter removed. 
+  {OpenHAB::DSL::Rules::BuilderDSL#on_start #on_start} is now a trigger for `core.SystemStartlevelTrigger`.
+  
 
 ### Features
 
@@ -173,6 +176,7 @@ here is a non-exhaustive list of significant departures from the original gem:
   openHAB will log a warning that the item is missing, and the trigger will not work. When the item is eventually created, the trigger will begin to work.
   This matches the behavior of DSL rules.
   Note that this only works for {OpenHAB::DSL::Rules::Terse terse rules} if they're created within a {OpenHAB::DSL::Rules::Builder rules.build} block.
+* {OpenHAB::DSL::Rules::BuilderDSL#on_start #on_start} supports creating a `core.SystemStartlevelTrigger`. Also see {OpenHAB::DSL::Rules::BuilderDSL#on_load #on_load}
 
 ### Bug Fixes
 

--- a/docs/examples/how_do_i.md
+++ b/docs/examples/how_do_i.md
@@ -343,7 +343,7 @@ end
 
 ```ruby
 rule 'initialize things' do
-  on_start # This also triggers whenever the script (re)loads
+  on_load # This triggers whenever the script (re)loads
   run { logger.info 'Here we go!' }
 end
 ```
@@ -487,7 +487,7 @@ This is available only on file-based rules.
 
 ```ruby
 rule 'delay something' do
-  on_start
+  on_load
   run { logger.info 'This will run immediately' }
   delay 10.seconds
   run { logger.info 'This will run 10 seconds after' }
@@ -499,7 +499,7 @@ either a file-based rule or in a UI based rule using {OpenHAB::DSL.after after}
 
 ```ruby
 rule 'delay something' do
-  on_start
+  on_load
   run do
     logger.info 'This will run immediately' 
     after(10.seconds) do

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -82,7 +82,7 @@ and then load rules in, then drop you into IRB.
 
  * See {OpenHAB::RSpec::Helpers} for all helper methods available in specs.
  * All items are reset to {NULL} before each spec.
- * `on_start` triggers are _not_ honored. Items will be reset to {NULL} before
+ * `on_load` triggers are _not_ honored. Items will be reset to {NULL} before
    the next spec anyway, so just don't waste the energy running them. You
    can still trigger rules manually.
  * Rule triggers besides item related triggers (such as cron or watchers)
@@ -132,10 +132,10 @@ or installation on Ubuntu or Debian with .debs. You may need to customize them
 if your installation is laid out differently. Additional OpenHAB or Karaf
 specific system properties will be set the same as OpenHAB would.
 
-| Variable                 | Default                 | Description                                                         |
-| ------------------------ | ----------------------- | ------------------------------------------------------------------- |
-| `$OPENHAB_HOME`          | `/usr/share/openhab`    | Location for the OpenHAB installation                               |
-| `$OPENHAB_RUNTIME`       | `$OPENHAB_HOME/runtime` | Location for OpenHAB's private Maven repository containing its JARs |
+| Variable           | Default                 | Description                                                         |
+| ------------------ | ----------------------- | ------------------------------------------------------------------- |
+| `$OPENHAB_HOME`    | `/usr/share/openhab`    | Location for the OpenHAB installation                               |
+| `$OPENHAB_RUNTIME` | `$OPENHAB_HOME/runtime` | Location for OpenHAB's private Maven repository containing its JARs |
 
 ## Transformations
 

--- a/docs/usage/misc/time.md
+++ b/docs/usage/misc/time.md
@@ -44,7 +44,7 @@ end
 
 ```ruby
 rule 'Timer example' do
-  on_start
+  on_load
   run do
     after(3.hours) { logger.info('3 hours have passed') }
   end

--- a/lib/openhab/core/items/contact_item.rb
+++ b/lib/openhab/core/items/contact_item.rb
@@ -18,7 +18,7 @@ module OpenHAB
       #
       # @example
       #   rule 'Log state of all doors on system startup' do
-      #     on_start
+      #     on_load
       #     run do
       #       Doors.each do |door|
       #         case door.state

--- a/lib/openhab/core/items/dimmer_item.rb
+++ b/lib/openhab/core/items/dimmer_item.rb
@@ -48,7 +48,7 @@ module OpenHAB
       #
       # @example
       #   rule 'Dim a switch on system startup over 100 seconds' do
-      #     on_start
+      #     on_load
       #     100.times do
       #       run { DimmerSwitch.dim }
       #       delay 1.second
@@ -57,7 +57,7 @@ module OpenHAB
       #
       # @example
       #   rule 'Dim a switch on system startup by 5, pausing every second' do
-      #     on_start
+      #     on_load
       #     100.step(-5, 0) do |level|
       #       run { DimmerSwitch << level }
       #       delay 1.second

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -154,7 +154,7 @@ module OpenHAB
     #
     # @example
     #   rule 'search for a suitable item' do
-    #     on_start
+    #     on_load
     #     triggered do
     #       # Send ON to DimmerTest if it exists, otherwise send it to SwitchTest
     #       (items['DimmerTest'] || items['SwitchTest'])&.on

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -110,8 +110,10 @@ module OpenHAB
         def extract_event(inputs)
           event = inputs&.dig("event")
           unless event
-            event = Struct.new(:event, :attachment, :command).new
-            event.command = inputs&.dig("command")
+            input_keys = inputs.to_h.keys.grep(/^[a-z_]+[a-zA-Z0-9_]*$/).grep_v("module") # only pick valid identifiers
+            event_members = %i[attachment] | input_keys.map(&:to_sym)
+            event = Struct.new(*event_members).new
+            input_keys.each { |key| event[key] = inputs[key] }
           end
           add_attachment(event, inputs)
         end

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -115,15 +115,15 @@ module OpenHAB
           event = inputs&.dig("event")
           attachment = @attachments[trigger_id(inputs)]
           if event
-            event.attachment = attachment if attachment
+            event.attachment = attachment
             return event
           end
 
           inputs = inputs.to_h
                          .select { |key, _value| key != "module" && INPUT_KEY_PATTERN.match?(key) }
                          .transform_keys(&:to_sym)
-                         .merge({ attachment: attachment })
-          Struct.new(*inputs.keys).new(*inputs.values)
+          inputs[:attachment] = attachment
+          Struct.new(*inputs.keys, keyword_init: true).new(inputs)
         end
 
         #

--- a/lib/openhab/log.rb
+++ b/lib/openhab/log.rb
@@ -26,7 +26,7 @@ module OpenHAB
   # @example The following entries are in a file named 'log_test.rb'
   #   rule 'foo' do
   #     run { logger.trace('Test logging at trace') } # 2020-12-03 18:05:20.903 [TRACE] [org.openhab.automation.jrubyscripting.foo] - Test logging at trace
-  #     on_start
+  #     on_load
   #   end
   #
   #

--- a/lib/openhab/rspec/example_group.rb
+++ b/lib/openhab/rspec/example_group.rb
@@ -94,7 +94,7 @@ module OpenHAB
         #     it "logs exceptions in rule execution" do
         #       expect(self.class.propagate_exceptions?).to be false
         #       rule do
-        #         on_start
+        #         on_load
         #         run { raise "exception is logged" }
         #       end
         #       expect(spec_log_lines).to include(match(/exception is logged/))

--- a/lib/openhab/rspec/suspend_rules.rb
+++ b/lib/openhab/rspec/suspend_rules.rb
@@ -18,7 +18,8 @@ module OpenHAB
             logger.trace { "Execute called with mod (#{mod&.to_string}) and inputs (#{inputs.inspect})" }
             logger.trace { "Event details #{inputs["event"].inspect}" } if inputs&.key?("event")
             trigger_conditions(inputs).process(mod: mod, inputs: inputs) do
-              process_queue(create_queue(inputs), mod, inputs)
+              event = extract_event(inputs)
+              process_queue(create_queue(event), mod, event)
             end
           rescue Exception => e
             raise if defined?(::RSpec) && ::RSpec.current_example.example_group.propagate_exceptions?

--- a/spec/openhab/log_spec.rb
+++ b/spec/openhab/log_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe OpenHAB::Log do
       rspec = self
       rule "log test", id: "log_test" do
         rspec.expect(logger.name).to rspec.eql "org.openhab.automation.jrubyscripting.rule.log_test"
-        on_start
+        on_load
         run do
           expect(logger.name).to eql "org.openhab.automation.jrubyscripting.rule.log_test"
         end
@@ -58,7 +58,7 @@ RSpec.describe OpenHAB::Log do
     it "uses the rule id inside a timer block inside a rule" do
       executed = false
       rule "log test" do
-        on_start
+        on_load
         run do
           after(1.second) do
             executed = true
@@ -122,7 +122,7 @@ RSpec.describe OpenHAB::Log do
 
     it "uses the class name inside a class method inside a rule" do
       rule "my rule" do
-        on_start
+        on_load
         run do
           expect(MyClass.logger_name).to eql "org.openhab.automation.jrubyscripting.MyClass"
           expect(MyClass.new.logger_name).to eql "org.openhab.automation.jrubyscripting.MyClass"


### PR DESCRIPTION
I haven't written the spec for it yet. RFC especially about the naming.

Currently implemented as
```ruby
rule do
  on_start at_level: 100
  run {}
end
```

The alternative that I considered was to create a separate trigger, e.g. `on_start_level 100` to differentiate against on_start but that might make it even more confusing.