### PR TITLE
automatically create pending dummy item proxy objects for rule triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,8 +99,8 @@ here is a non-exhaustive list of significant departures from the original gem:
 * The top-level `groups` method providing access to only {GroupItem}s has been
   removed. Use `items.grep(GroupItem)` if you would like to filter to only
   groups.
-* `GenericItem#id` no longer exists; just use
-  {GenericItem#to_s GenericItem#to_s} which does what `#id` used to do.
+* `GemericItem#id` no longer exists; just use
+  {Item#to_s Item#to_s} which does what `#id` used to do.
 * `states?(*items)` helper is gone. Just use `items.all?(:state?)`, or in
   the rare cased you used `states?(*items, things: true)`, use
   `items.all? { |i| i.state? && i.things.all?(&:online?) }`.
@@ -109,8 +109,8 @@ here is a non-exhaustive list of significant departures from the original gem:
 * {GroupItem#all_members GroupItem#all_members} no
   longer has a `filter` parameter; use `grep` if you want just {GroupItem}s.
 * `create_timer` no longer exists as an alias for {after}.
-* `GenericItem#meta` is no longer a supported alias for
-  {GenericItem#metadata GenericItem#metadata}.
+* `Item#meta` is no longer a supported alias for
+  {Item#metadata Item#metadata}.
 * Triggers (such as {OpenHAB::DSL::Rules::BuilderDSL#changed changed},
   {OpenHAB::DSL::Rules::BuilderDSL#updated updated}, and
   {OpenHAB::DSL::Rules::BuilderDSL#received_command received_command} that
@@ -169,6 +169,10 @@ here is a non-exhaustive list of significant departures from the original gem:
 * Add `#ago` and `#from_now` methods to {Duration}.
 * The ability to designate how metadata should be persisted or not, via {OpenHAB::DSL.provider}.
 * {java.util.Map} and {java.util.List} now more fully implement the expected interfaces of `Hash` and `Array`, so you don't need to explicitly convert (as much) anymore.
+* If you reference an item that does not currently exist in a rule trigger, instead of raising `MethodMissing` or `NameError`, the trigger will be created anyway.
+  openHAB will log a warning that the item is missing, and the trigger will not work. When the item is eventually created, the trigger will begin to work.
+  This matches the behavior of DSL rules.
+  Note that this only works for {OpenHAB::DSL::Rules::Terse terse rules} if they're created within a {OpenHAB::DSL::Rules::Builder rules.build} block.
 
 ### Bug Fixes
 

--- a/docs/examples/how_do_i.md
+++ b/docs/examples/how_do_i.md
@@ -653,7 +653,7 @@ end
 metadata = My_Item.metadata['namespace'].value
 ```
 
-See {GenericItem#metadata}
+See {Item#metadata}
 
 ## Use Persistence
 

--- a/lib/openhab/core/entity_lookup.rb
+++ b/lib/openhab/core/entity_lookup.rb
@@ -3,9 +3,9 @@
 module OpenHAB
   module Core
     #
-    # Manages access to OpenHAB entities
+    # Manages access to openHAB entities
     #
-    # You can access OpenHAB items and things directly using their name, anywhere `EntityLookup` is available.
+    # You can access openHAB items and things directly using their name, anywhere `EntityLookup` is available.
     #
     # @note Thing UIDs are separated by a colon `:`. Since it is not a valid symbol for an identifier,
     #   it must be replaced with an underscore `_`. So to access `astro:sun:home`, use `astro_sun_home`
@@ -16,7 +16,7 @@ module OpenHAB
     #
     # @example Accessing Items and Groups
     #   gAll_Lights       # Access the gAll_Lights group. It is the same as items["gAll_Lights"]
-    #   Kitchen_Light.on  # The OpenHAB object for the Kitchen_Light item and send an ON command
+    #   Kitchen_Light.on  # The openHAB object for the Kitchen_Light item and send an ON command
     #
     # @example Accessing Things
     #   smtp_mail_local.send_mail('me@example.com', 'Subject', 'Dear Person, ...')
@@ -24,110 +24,139 @@ module OpenHAB
     #   things['smtp:mail:local'].send_mail('me@example.com', 'Subject', 'Dear Person, ...')
     #
     module EntityLookup
+      # @!visibility private
+      module ClassMethods
+        # @!attribute [w] create_dummy_items
+        # @return [true,false]
+        def create_dummy_items=(value)
+          @create_dummy_items = value
+        end
+
+        # @return [Boolean] if dummy items should be created in this context
+        def create_dummy_items?
+          @create_dummy_items
+        end
+      end
+
+      # @!visibility private
+      def self.included(klass)
+        klass.singleton_class.include(ClassMethods)
+      end
+
       #
-      # Automatically looks up OpenHAB items and things in appropriate registries
+      # Automatically looks up openHAB items and things in appropriate registries
       #
-      # @return [GenericItem, Things::Thing, nil]
+      # @return [Item, Things::Thing, nil]
       #
-      def method_missing(method, *args, &block)
-        logger.trace("method missing, performing OpenHab Lookup for: #{method}")
+      def method_missing(method, *)
+        logger.trace("method missing, performing openHAB Lookup for: #{method}")
+        EntityLookup.lookup_entity(method,
+                                   create_dummy_items: self.class.respond_to?(:create_dummy_items?) &&
+                                     self.class.create_dummy_items?) || super
+      end
+
+      # @!visibility private
+      def respond_to_missing?(method, *)
+        logger.trace("Checking if openHAB entities exist for #{method}")
         EntityLookup.lookup_entity(method) || super
       end
 
       # @!visibility private
-      def respond_to_missing?(method_name, _include_private = false)
-        logger.trace("Checking if OpenHAB entities exist for #{method_name}")
-        method_name = method_name.to_s if method_name.is_a?(Symbol)
-
-        method_name == "scriptLoaded" ||
-          method_name == "scriptUnloaded" ||
-          EntityLookup.lookup_entity(method_name) ||
-          super
-      end
-
-      #
-      # Looks up an OpenHAB entity
-      #  items are checked first, then things
-      #
-      # @!visibility private
-      #
-      # @param [String] name of entity to lookup in item or thing registry
-      #
-      # @return [GenericItem, Things::Thing, nil]
-      #
-      def self.lookup_entity(name)
-        lookup_item(name) || lookup_thing_const(name)
-      end
-
-      #
-      # Looks up a Thing in the OpenHAB registry
-      #
-      # @!visibility private
-      #
-      # @param [String] uid name of Thing to lookup in Thing registry
-      #
-      # @return [Things::Thing, nil]
-      #
-      def self.lookup_thing(uid)
-        logger.trace("Looking up thing '#{uid}'")
-        uid = uid.to_s if uid.is_a?(Symbol)
-
-        uid = Things::ThingUID.new(uid) unless uid.is_a?(Things::ThingUID)
-        thing = $things.get(uid)
-        return unless thing
-
-        logger.trace("Retrieved Thing(#{thing}) from registry for uid: #{uid}")
-        Things::Proxy.new(thing)
-      end
-
-      #
-      # Looks up a Thing in the OpenHAB registry replacing `_` with `:`
-      #
-      # @!visibility private
-      #
-      # @param [String] name of Thing to lookup in Thing registry
-      #
-      # @return [Things::Thing, nil]
-      #
-      def self.lookup_thing_const(name)
-        name = name.to_s if name.is_a?(Symbol)
-
-        if name.is_a?(String)
-          # Thing UIDs have at least 3 segments, separated by `_`
-          return if name.count("_") < 2
-
-          # Convert from _ syntax to :
-          name = name.tr("_", ":")
+      def instance_eval_with_dummy_items(&block)
+        DSL::ThreadLocal.thread_local(openhab_create_dummy_items: self.class.create_dummy_items?) do
+          instance_eval(&block)
         end
-        lookup_thing(name)
       end
 
-      #
-      # Lookup OpenHAB items in item registry
-      #
-      # @!visibility private
-      #
-      # @param [String] name of item to lookup
-      #
-      # @return [GenericItem, nil]
-      #
-      def self.lookup_item(name)
-        logger.trace("Looking up item '#{name}'")
-        name = name.to_s if name.is_a?(Symbol)
-        item = $ir.get(name)
-        Items::Proxy.new(item) unless item.nil?
+      class << self
+        #
+        # Looks up an openHAB entity
+        #  items are checked first, then things
+        #
+        # @!visibility private
+        #
+        # @param [String] name of entity to lookup in item or thing registry
+        # @param [true, false] create_dummy_items If a dummy {Item} should be created if an actual item can't be found
+        #
+        # @return [Item, Things::Thing, nil]
+        #
+        def lookup_entity(name, create_dummy_items: false)
+          # make sure we have a nil return
+          create_dummy_items = nil if create_dummy_items == false
+          lookup_item(name) || lookup_thing_const(name) || (create_dummy_items && Items::Proxy.new(name.to_sym))
+        end
+
+        #
+        # Looks up a Thing in the openHAB registry
+        #
+        # @!visibility private
+        #
+        # @param [String] uid name of Thing to lookup in Thing registry
+        #
+        # @return [Things::Thing, nil]
+        #
+        def lookup_thing(uid)
+          logger.trace("Looking up thing '#{uid}'")
+          uid = uid.to_s if uid.is_a?(Symbol)
+
+          uid = Things::ThingUID.new(uid) unless uid.is_a?(Things::ThingUID)
+          thing = $things.get(uid)
+          return unless thing
+
+          logger.trace("Retrieved Thing(#{thing}) from registry for uid: #{uid}")
+          Things::Proxy.new(thing)
+        end
+
+        #
+        # Looks up a Thing in the openHAB registry replacing `_` with `:`
+        #
+        # @!visibility private
+        #
+        # @param [String] name of Thing to lookup in Thing registry
+        #
+        # @return [Things::Thing, nil]
+        #
+        def lookup_thing_const(name)
+          name = name.to_s if name.is_a?(Symbol)
+
+          if name.is_a?(String)
+            # Thing UIDs have at least 3 segments, separated by `_`
+            return if name.count("_") < 2
+
+            # Convert from _ syntax to :
+            name = name.tr("_", ":")
+          end
+          lookup_thing(name)
+        end
+
+        #
+        # Lookup OpenHAB items in item registry
+        #
+        # @!visibility private
+        #
+        # @param [String] name of item to lookup
+        #
+        # @return [Item, nil]
+        #
+        def lookup_item(name)
+          logger.trace("Looking up item '#{name}'")
+          name = name.to_s if name.is_a?(Symbol)
+          item = $ir.get(name)
+          Items::Proxy.new(item) unless item.nil?
+        end
       end
     end
   end
 end
 
 #
-# Implements const_missing to return OpenHAB items or things if mapping to missing name if they exist
+# Implements const_missing to return openHAB items or things if mapping to missing name if they exist
 #
 # @param [String] name Capital string that was not set as a constant and to be looked up
 #
-# @return [Object] OpenHAB Item or Thing if their name exist in OpenHAB item and thing regestries
+# @return [Object] openHAB Item or Thing if their name exist in openHAB item and thing regestries
 #
 def Object.const_missing(name)
-  OpenHAB::Core::EntityLookup.lookup_entity(name) || super
+  OpenHAB::Core::EntityLookup.lookup_entity(name,
+                                            create_dummy_items: Thread.current[:openhab_create_dummy_items]) || super
 end

--- a/lib/openhab/core/events/item_channel_link.rb
+++ b/lib/openhab/core/events/item_channel_link.rb
@@ -17,7 +17,7 @@ module OpenHAB
 
         #
         # @!attribute [r] item
-        # @return [GenericItem] The item that was linked or unlinked
+        # @return [Item] The item that was linked or unlinked
         #
         def item
           EntityLookup.lookup_item(itemName)

--- a/lib/openhab/core/events/item_event.rb
+++ b/lib/openhab/core/events/item_event.rb
@@ -11,7 +11,7 @@ module OpenHAB
       class ItemEvent < AbstractEvent
         #
         # @!attribute [r] item
-        # @return [GenericItem] The item that triggered this event.
+        # @return [Item] The item that triggered this event.
         #
         def item
           EntityLookup.lookup_item(item_name)

--- a/lib/openhab/core/items.rb
+++ b/lib/openhab/core/items.rb
@@ -25,6 +25,7 @@ module OpenHAB
             Object.const_set(const_name, k) unless Object.const_defined?(const_name)
           end
           Object.const_set(:GenericItem, GenericItem) unless Object.const_defined?(:GenericItem)
+          Object.const_set(:Item, Item) unless Object.const_defined?(:Item)
         end
 
         private

--- a/lib/openhab/core/items/accepted_data_types.rb
+++ b/lib/openhab/core/items/accepted_data_types.rb
@@ -13,12 +13,12 @@ module OpenHAB
       end
 
       module AcceptedDataTypes
-        # @see GenericItem#accepted_command_types
+        # @see Item#accepted_command_types
         def accepted_command_types
           super.map { |k| k.is_a?(java.lang.Class) ? k.ruby_class : k }
         end
 
-        # @see GenericItem#accepted_data_types
+        # @see Item#accepted_data_types
         def accepted_data_types
           super.map { |k| k.is_a?(java.lang.Class) ? k.ruby_class : k }
         end

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -10,15 +10,9 @@ module OpenHAB
       #
       # @see https://www.openhab.org/javadoc/latest/org/openhab/core/items/genericitem
       #
-      # @!attribute [r] name
-      #   The item's name.
-      #   @return [String]
-      #
-      # @!attribute [r] label
-      #   The item's descriptive label.
-      #   @return [String, nil]
-      #
       class GenericItem
+        # @!parse include Item
+
         # rubocop:disable Naming/MethodName these mimic Java fields, which are
         # actually methods
         class << self
@@ -36,7 +30,10 @@ module OpenHAB
 
           # @!visibility private
           #
-          # Override to support Proxy
+          # Override to support {Proxy}
+          #
+          # Item.=== isn't actually included (on the Ruby side) into
+          # {GenericItem}
           #
           def ===(other)
             other.is_a?(self)
@@ -44,11 +41,13 @@ module OpenHAB
         end
         # rubocop:enable Naming/MethodName
 
-        # @!attribute [r] accepted_command_types
-        #   @return [Array<Class>] An array of {Command}s that can be sent as commands to this item
+        # @!attribute [r] name
+        #   The item's name.
+        #   @return [String]
 
-        # @!attribute [r] accepted_data_types
-        #   @return [Array<Class>] An array of {State}s that can be sent as commands to this item
+        # @!attribute [r] label
+        #   The item's descriptive label.
+        #   @return [String, nil]
 
         alias_method :hash, :hash_code
 
@@ -61,6 +60,35 @@ module OpenHAB
         # @return [State]
         #
         alias_method :raw_state, :state
+
+        #
+        # Check if the item has a state (not {UNDEF} or {NULL})
+        #
+        # @return [true, false]
+        #
+        def state?
+          !raw_state.is_a?(Types::UnDefType)
+        end
+
+        #
+        # @!attribute [r] state
+        # @return [State, nil]
+        #   OpenHAB item state if state is not {UNDEF} or {NULL}, nil otherwise.
+        #   This makes it easy to use with the
+        #   [Ruby safe navigation operator `&.`](https://ruby-doc.org/core-2.6/doc/syntax/calling_methods_rdoc.html)
+        #   Use {#undef?} or {#null?} to check for those states.
+        #
+        def state
+          raw_state if state?
+        end
+
+        # @!method null?
+        #   Check if the item state == {NULL}
+        #   @return [true,false]
+
+        # @!method undef?
+        #   Check if the item state == {UNDEF}
+        #   @return [true,false]
 
         #
         # Send a command to this item
@@ -91,6 +119,10 @@ module OpenHAB
 
         # @!parse alias_method :<<, :command
 
+        # @!method refresh
+        #   Send the {REFRESH} command to the item
+        #   @return [Item] `self`
+
         #
         # Send an update to this item
         #
@@ -104,200 +136,6 @@ module OpenHAB
           $events.post_update(self, state)
           Proxy.new(self)
         end
-
-        #
-        # Check if the item has a state (not {UNDEF} or {NULL})
-        #
-        # @return [true, false]
-        #
-        def state?
-          !raw_state.is_a?(Types::UnDefType)
-        end
-
-        #
-        # @!attribute [r] state
-        # @return [State, nil]
-        #   OpenHAB item state if state is not {UNDEF} or {NULL}, nil otherwise.
-        #   This makes it easy to use with the
-        #   [Ruby safe navigation operator `&.`](https://ruby-doc.org/core-2.6/doc/syntax/calling_methods_rdoc.html)
-        #   Use {#undef?} or {#null?} to check for those states.
-        #
-        def state
-          raw_state if state?
-        end
-
-        #
-        # The item's {#label} if one is defined, otherwise it's {#name}.
-        #
-        # @return [String]
-        #
-        def to_s
-          label || name
-        end
-
-        #
-        # @!attribute [r] groups
-        #
-        # Return all groups that this item is part of
-        #
-        # @return [Array<Group>] All groups that this item is part of
-        #
-        def groups
-          group_names.map { |name| EntityLookup.lookup_item(name) }.compact
-        end
-
-        # rubocop:disable Layout/LineLength
-
-        # @!attribute [r] metadata
-        # @return [Metadata::NamespaceHash]
-        #
-        # Access to the item's metadata.
-        #
-        # Both the return value of this method as well as the individual
-        # namespaces can be treated as Hashes.
-        #
-        # Examples assume the following items:
-        #
-        # ```xtend
-        # Switch Item1 { namespace1="value" [ config1="foo", config2="bar" ] }
-        # String StringItem1
-        # ```
-        #
-        # @example Check namespace's existence
-        #   Item1.metadata["namespace"].nil?
-        #   Item1.metadata.key?("namespace")
-        #
-        # @example Access item's metadata value
-        #   Item1.metadata["namespace1"].value
-        #
-        # @example Access namespace1's configuration
-        #   Item1.metadata["namespace1"]["config1"]
-        #
-        # @example Safely search for the specified value - no errors are raised, only nil returned if a key in the chain doesn"t exist
-        #   Item1.metadata.dig("namespace1", "config1") # => "foo"
-        #   Item1.metadata.dig("namespace2", "config1") # => nil
-        #
-        # @example Set item's metadata value, preserving its config
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace1"].value = "new value"
-        #   # Item1's metadata after: {"namespace1"=>["new value", {"config1"=>"foo", "config2"=>"bar"]}}
-        #
-        # @example Set item's metadata config, preserving its value
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace1"].replace({ "scooby"=>"doo" })
-        #   # Item1's metadata after: {"namespace1"=>["value", {scooby="doo"}]}
-        #
-        # @example Set a namespace to a new value and config in one line
-        #   # Item1's metadata before: {"namespace1"=>"value", {"config1"=>"foo", "config2"=>"bar"}}
-        #   Item1.metadata["namespace1"] = "new value", { "scooby"=>"doo" }
-        #   # Item1's metadata after: {"namespace1"=>["new value", {scooby="doo"}]}
-        #
-        # @example Set item's metadata value and clear its previous config
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace1"] = "new value"
-        #   # Item1's metadata after: {"namespace1"=>"value" }
-        #
-        # @example Set item's metadata config, set its value to nil, and wiping out previous config
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace1"] = { "newconfig"=>"value" }
-        #   # Item1's metadata after: {"namespace1"=>{"config1"=>"foo", "config2"=>"bar"}}
-        #
-        # @example Update namespace1's specific configuration, preserving its value and other config
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace1"]["config1"] = "doo"
-        #   # Item1's metadata will be: {"namespace1"=>["value", {"config1"=>"doo", "config2"=>"bar"}]}
-        #
-        # @example Add a new configuration to namespace1
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace1"]["config3"] = "boo"
-        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar", config3="boo"}]}
-        #
-        # @example Delete a config
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace1"].delete("config2")
-        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo"}]}
-        #
-        # @example Add a namespace and set it to a value
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace2"] = "qx"
-        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}], "namespace2"=>"qx"}
-        #
-        # @example Add a namespace and set it to a value and config
-        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace2"] = "qx", { "config1"=>"doo" }
-        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}], "namespace2"=>["qx", {"config1"=>"doo"}]}
-        #
-        # @example Enumerate Item1's namespaces
-        #   Item1.metadata.each { |namespace, metadata| logger.info("Item1's namespace: #{namespace}=#{metadata}") }
-        #
-        # @example Add metadata from a hash
-        #   Item1.metadata.merge!({"namespace1"=>{"foo", {"config1"=>"baz"} ], "namespace2"=>{"qux", {"config"=>"quu"} ]})
-        #
-        # @example Merge Item2's metadata into Item1's metadata
-        #   Item1.metadata.merge!(Item2.metadata)
-        #
-        # @example Delete a namespace
-        #   Item1.metadata.delete("namespace1")
-        #
-        # @example Delete all metadata of the item
-        #   Item1.metadata.clear
-        #
-        # @example Does this item have any metadata?
-        #   Item1.metadata.any?
-        #
-        # @example Store another item's state
-        #   StringItem1.update "TEST"
-        #   Item1.metadata["other_state"] = StringItem1.state
-        #
-        # @example Store event's state
-        #   rule "save event state" do
-        #     changed StringItem1
-        #     run { |event| Item1.metadata["last_event"] = event.was }
-        #   end
-        #
-        # @example If the namespace already exists: Update the value of a namespace but preserve its config; otherwise create a new namespace with the given value and nil config.
-        #   Item1.metadata["namespace"] = "value", Item1.metadata["namespace"]
-        #
-        # @example Copy another namespace
-        #   # Item1's metadata before: {"namespace2"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #   Item1.metadata["namespace"] = Item1.metadata["namespace2"]
-        #   # Item1's metadata after: {"namespace2"=>["value", {"config1"=>"foo", "config2"=>"bar"}], "namespace"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
-        #
-        def metadata
-          @metadata ||= Metadata::NamespaceHash.new(name)
-        end
-        # rubocop:enable Layout/LineLength
-
-        # Return the item's thing if this item is linked with a thing. If an item is linked to more than one thing,
-        # this method only returns the first thing.
-        #
-        # @return [Thing] The thing associated with this item or nil
-        def thing
-          all_linked_things.first
-        end
-        alias_method :linked_thing, :thing
-
-        # Returns all of the item's linked things.
-        #
-        # @return [Array<Thing>] An array of things or an empty array
-        def things
-          registry = OSGi.service("org.openhab.core.thing.link.ItemChannelLinkRegistry")
-          channels = registry.get_bound_channels(name).to_a
-          channels.map(&:thing_uid).uniq.map { |tuid| EntityLookup.lookup_thing(tuid) }.compact
-        end
-        alias_method :all_linked_things, :things
-
-        # @!method null?
-        #   Check if the item state == {NULL}
-        #   @return [true,false]
-
-        # @!method undef?
-        #   Check if the item state == {UNDEF}
-        #   @return [true,false]
-
-        # @!method refresh
-        #   Send the {REFRESH} command to the item
-        #   @return [GenericItem] `self`
 
         # @!visibility private
         def format_command(command)
@@ -327,23 +165,6 @@ module OpenHAB
 
           type.to_s
         end
-
-        # @return [String]
-        def inspect
-          s = "#<OpenHAB::Core::Items::#{type}Item#{type_details} #{name} #{label.inspect} state=#{raw_state.inspect}"
-          s += " category=#{category.inspect}" if category
-          s += " tags=#{tags.to_a.inspect}" unless tags.empty?
-          s += " groups=#{group_names}" unless group_names.empty?
-          meta = metadata.to_h
-          s += " metadata=#{meta.inspect}" unless meta.empty?
-          "#{s}>"
-        end
-
-        private
-
-        # Allows sub-classes to append additional details to the type in an inspect string
-        # @return [String]
-        def type_details; end
       end
     end
   end

--- a/lib/openhab/core/items/group_item.rb
+++ b/lib/openhab/core/items/group_item.rb
@@ -33,7 +33,7 @@ module OpenHAB
       # ```
       #
       # @!attribute [r] base_item
-      #   @return [GenericItem, nil] A typed item if the group has a particular type.
+      #   @return [Item, nil] A typed item if the group has a particular type.
       #
       # @example Operate on items in a group using enumerable methods
       #   logger.info("Total Temperatures: #{Temperatures.members.count}")
@@ -99,7 +99,9 @@ module OpenHAB
 
           # @return [String]
           def inspect
-            "#<OpenHAB::Core::Items::GroupItems::Members #{name} #{map(&:name).inspect}>"
+            r = "#<OpenHAB::Core::Items::GroupItems::Members #{name}"
+            r += " #{map(&:name).inspect}>" unless @group.__getobj__.nil?
+            "#{r}>"
           end
           alias_method :to_s, :inspect
         end
@@ -120,7 +122,7 @@ module OpenHAB
         # @see Enumerable
         #
         def members
-          Members.new(self)
+          Members.new(Proxy.new(self))
         end
 
         #

--- a/lib/openhab/core/items/item.rb
+++ b/lib/openhab/core/items/item.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module Core
+    module Items
+      # @interface
+      java_import org.openhab.core.items.Item
+
+      #
+      # The core features of an openHAB item.
+      #
+      module Item
+        class << self
+          # @!visibility private
+          #
+          # Override to support {Proxy}
+          #
+          def ===(other)
+            other.is_a?(self)
+          end
+        end
+
+        # @!attribute [r] name
+        #   The item's name.
+        #   @return [String]
+
+        # @!attribute [r] label
+        #   The item's descriptive label.
+        #   @return [String, nil]
+
+        # @!attribute [r] accepted_command_types
+        #   @return [Array<Class>] An array of {Command}s that can be sent as commands to this item
+
+        # @!attribute [r] accepted_data_types
+        #   @return [Array<Class>] An array of {State}s that can be sent as commands to this item
+
+        #
+        # The item's {#label} if one is defined, otherwise it's {#name}.
+        #
+        # @return [String]
+        #
+        def to_s
+          label || name
+        end
+
+        #
+        # @!attribute [r] groups
+        #
+        # Return all groups that this item is part of
+        #
+        # @return [Array<Group>] All groups that this item is part of
+        #
+        def groups
+          group_names.map { |name| EntityLookup.lookup_item(name) }.compact
+        end
+
+        # rubocop:disable Layout/LineLength
+
+        # @!attribute [r] metadata
+        # @return [Metadata::NamespaceHash]
+        #
+        # Access to the item's metadata.
+        #
+        # Both the return value of this method as well as the individual
+        # namespaces can be treated as Hashes.
+        #
+        # Examples assume the following items:
+        #
+        # ```xtend
+        # Switch Item1 { namespace1="value" [ config1="foo", config2="bar" ] }
+        # String StringItem1
+        # ```
+        #
+        # @example Check namespace's existence
+        #   Item1.metadata["namespace"].nil?
+        #   Item1.metadata.key?("namespace")
+        #
+        # @example Access item's metadata value
+        #   Item1.metadata["namespace1"].value
+        #
+        # @example Access namespace1's configuration
+        #   Item1.metadata["namespace1"]["config1"]
+        #
+        # @example Safely search for the specified value - no errors are raised, only nil returned if a key in the chain doesn"t exist
+        #   Item1.metadata.dig("namespace1", "config1") # => "foo"
+        #   Item1.metadata.dig("namespace2", "config1") # => nil
+        #
+        # @example Set item's metadata value, preserving its config
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace1"].value = "new value"
+        #   # Item1's metadata after: {"namespace1"=>["new value", {"config1"=>"foo", "config2"=>"bar"]}}
+        #
+        # @example Set item's metadata config, preserving its value
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace1"].replace({ "scooby"=>"doo" })
+        #   # Item1's metadata after: {"namespace1"=>["value", {scooby="doo"}]}
+        #
+        # @example Set a namespace to a new value and config in one line
+        #   # Item1's metadata before: {"namespace1"=>"value", {"config1"=>"foo", "config2"=>"bar"}}
+        #   Item1.metadata["namespace1"] = "new value", { "scooby"=>"doo" }
+        #   # Item1's metadata after: {"namespace1"=>["new value", {scooby="doo"}]}
+        #
+        # @example Set item's metadata value and clear its previous config
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace1"] = "new value"
+        #   # Item1's metadata after: {"namespace1"=>"value" }
+        #
+        # @example Set item's metadata config, set its value to nil, and wiping out previous config
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace1"] = { "newconfig"=>"value" }
+        #   # Item1's metadata after: {"namespace1"=>{"config1"=>"foo", "config2"=>"bar"}}
+        #
+        # @example Update namespace1's specific configuration, preserving its value and other config
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace1"]["config1"] = "doo"
+        #   # Item1's metadata will be: {"namespace1"=>["value", {"config1"=>"doo", "config2"=>"bar"}]}
+        #
+        # @example Add a new configuration to namespace1
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace1"]["config3"] = "boo"
+        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar", config3="boo"}]}
+        #
+        # @example Delete a config
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace1"].delete("config2")
+        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo"}]}
+        #
+        # @example Add a namespace and set it to a value
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace2"] = "qx"
+        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}], "namespace2"=>"qx"}
+        #
+        # @example Add a namespace and set it to a value and config
+        #   # Item1's metadata before: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace2"] = "qx", { "config1"=>"doo" }
+        #   # Item1's metadata after: {"namespace1"=>["value", {"config1"=>"foo", "config2"=>"bar"}], "namespace2"=>["qx", {"config1"=>"doo"}]}
+        #
+        # @example Enumerate Item1's namespaces
+        #   Item1.metadata.each { |namespace, metadata| logger.info("Item1's namespace: #{namespace}=#{metadata}") }
+        #
+        # @example Add metadata from a hash
+        #   Item1.metadata.merge!({"namespace1"=>{"foo", {"config1"=>"baz"} ], "namespace2"=>{"qux", {"config"=>"quu"} ]})
+        #
+        # @example Merge Item2's metadata into Item1's metadata
+        #   Item1.metadata.merge!(Item2.metadata)
+        #
+        # @example Delete a namespace
+        #   Item1.metadata.delete("namespace1")
+        #
+        # @example Delete all metadata of the item
+        #   Item1.metadata.clear
+        #
+        # @example Does this item have any metadata?
+        #   Item1.metadata.any?
+        #
+        # @example Store another item's state
+        #   StringItem1.update "TEST"
+        #   Item1.metadata["other_state"] = StringItem1.state
+        #
+        # @example Store event's state
+        #   rule "save event state" do
+        #     changed StringItem1
+        #     run { |event| Item1.metadata["last_event"] = event.was }
+        #   end
+        #
+        # @example If the namespace already exists: Update the value of a namespace but preserve its config; otherwise create a new namespace with the given value and nil config.
+        #   Item1.metadata["namespace"] = "value", Item1.metadata["namespace"]
+        #
+        # @example Copy another namespace
+        #   # Item1's metadata before: {"namespace2"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #   Item1.metadata["namespace"] = Item1.metadata["namespace2"]
+        #   # Item1's metadata after: {"namespace2"=>["value", {"config1"=>"foo", "config2"=>"bar"}], "namespace"=>["value", {"config1"=>"foo", "config2"=>"bar"}]}
+        #
+        def metadata
+          @metadata ||= Metadata::NamespaceHash.new(name)
+        end
+        # rubocop:enable Layout/LineLength
+
+        # Return the item's thing if this item is linked with a thing. If an item is linked to more than one thing,
+        # this method only returns the first thing.
+        #
+        # @return [Thing] The thing associated with this item or nil
+        def thing
+          all_linked_things.first
+        end
+        alias_method :linked_thing, :thing
+
+        # Returns all of the item's linked things.
+        #
+        # @return [Array<Thing>] An array of things or an empty array
+        def things
+          registry = OSGi.service("org.openhab.core.thing.link.ItemChannelLinkRegistry")
+          channels = registry.get_bound_channels(name).to_a
+          channels.map(&:thing_uid).uniq.map { |tuid| EntityLookup.lookup_thing(tuid) }.compact
+        end
+        alias_method :all_linked_things, :things
+
+        # @return [String]
+        def inspect
+          s = "#<OpenHAB::Core::Items::#{type}Item#{type_details} #{name} #{label.inspect} state=#{raw_state.inspect}"
+          s += " category=#{category.inspect}" if category
+          s += " tags=#{tags.to_a.inspect}" unless tags.empty?
+          s += " groups=#{group_names}" unless group_names.empty?
+          meta = metadata.to_h
+          s += " metadata=#{meta.inspect}" unless meta.empty?
+          "#{s}>"
+        end
+
+        private
+
+        # Allows sub-classes to append additional details to the type in an inspect string
+        # @return [String]
+        def type_details; end
+      end
+    end
+  end
+end
+
+# @!parse Item = OpenHAB::Core::Items::Item

--- a/lib/openhab/core/items/metadata/hash.rb
+++ b/lib/openhab/core/items/metadata/hash.rb
@@ -111,7 +111,7 @@ module OpenHAB
           end
 
           # @!attribute [r] item
-          #   @return [GenericItem, nil] The item this namespace is attached to.
+          #   @return [Item, nil] The item this namespace is attached to.
           def item
             return nil unless attached?
 

--- a/lib/openhab/core/items/provider.rb
+++ b/lib/openhab/core/items/provider.rb
@@ -4,7 +4,7 @@ module OpenHAB
   module Core
     module Items
       #
-      # Provides {GenericItem Items} created in Ruby to openHAB
+      # Provides {Item Items} created in Ruby to openHAB
       #
       class Provider < Core::Provider
         include org.openhab.core.items.ItemProvider
@@ -25,7 +25,7 @@ module OpenHAB
         #
         # @param [String] item_name
         # @param [true, false] recursive
-        # @return [GenericItem, nil] The removed item, if found.
+        # @return [Item, nil] The removed item, if found.
         #
         def remove(item_name, recursive = false) # rubocop:disable Style/OptionalBooleanParameter matches Java method
           return nil unless @elements.key?(item_name)

--- a/lib/openhab/core/items/proxy.rb
+++ b/lib/openhab/core/items/proxy.rb
@@ -1,31 +1,49 @@
 # frozen_string_literal: true
 
 require "delegate"
-require "forwardable"
 
 module OpenHAB
   module Core
     module Items
-      # Class is a proxy to underlying item
+      # Class is a proxy to underlying {Item}
       # @!visibility private
       class Proxy < Delegator
-        extend Forwardable
-        def_delegators :__getobj__, :class, :is_a?, :kind_of?
+        # Not really an Item, but pretends to be
+        # @!parse include Item
+
+        # @return [String]
+        attr_reader :name
 
         #
         # Set the proxy item (called by super)
         #
         def __setobj__(item)
-          # Convert name to java version for faster lookups
-          @item_name = item.name.to_java
+          @name = item.name
+          # Convert name to Java version for faster lookups
+          @java_name = item.name.to_java
         end
 
         #
         # Lookup item from item registry
         #
         def __getobj__
-          $ir.get(@item_name)
+          r = $ir.get(@name)
+          return yield if r.nil? && block_given?
+
+          r
         end
+
+        # @return [Module]
+        def class
+          return Item if __getobj__.nil?
+
+          __getobj__.class
+        end
+
+        def is_a?(klass)
+          klass == Item || __getobj__.is_a?(klass)
+        end
+        alias_method :kind_of?, :is_a?
 
         #
         # Need to check if `self` _or_ the delegate is an instance of the
@@ -62,6 +80,28 @@ module OpenHAB
         # @!visibility private
         def !=(other)
           !(self == other) # rubocop:disable Style/InverseMethods
+        end
+
+        # @return [GroupItem::Members]
+        # @raise [NoMethodError] if item is not a GroupItem, or a dummy.
+        def members
+          return super unless __getobj__.nil?
+
+          GroupItem::Members.new(self)
+        end
+
+        # needs to return `false` if we know we're not a {GroupItem}
+        def respond_to?(method, *)
+          return __getobj__.nil? if method.to_sym == :members
+
+          super
+        end
+
+        # needs to return `false` if we know we're not a {GroupItem}
+        def respond_to_missing?(method, *)
+          return __getobj__.nil? if method.to_sym == :members
+
+          super
         end
       end
     end

--- a/lib/openhab/core/items/registry.rb
+++ b/lib/openhab/core/items/registry.rb
@@ -10,7 +10,7 @@ module OpenHAB
   module Core
     module Items
       #
-      # Provides access to all OpenHAB {GenericItem items}, and acts like an array.
+      # Provides access to all OpenHAB {Item items}, and acts like an array.
       #
       class Registry
         include LazyArray
@@ -18,7 +18,7 @@ module OpenHAB
 
         # Fetches the named item from the the ItemRegistry
         # @param [String] name
-        # @return [GenericItem] Item from registry, nil if item missing or requested item is a Group Type
+        # @return [Item] Item from registry, nil if item missing or requested item is a Group Type
         def [](name)
           EntityLookup.lookup_item(name)
         rescue org.openhab.core.items.ItemNotFoundException
@@ -57,11 +57,11 @@ module OpenHAB
         #
         # The item must be a managed item (typically created by Ruby or in the UI).
         #
-        # @param [String, GenericItem] item_name
+        # @param [String, Item] item_name
         # @param recursive [true, false] Remove the item's members if it's a group
-        # @return [GenericItem, nil] The removed item, if found.
+        # @return [Item, nil] The removed item, if found.
         def remove(item_name, recursive: false)
-          item_name = item_name.name if item_name.is_a?(GenericItem)
+          item_name = item_name.name if item_name.is_a?(Item)
           provider = Provider.registry.provider_for(item_name)
           unless provider.is_a?(org.openhab.core.common.registry.ManagedProvider)
             raise "Cannot remove item #{item_name} from non-managed provider #{provider.inspect}"

--- a/lib/openhab/core/items/semantics.rb
+++ b/lib/openhab/core/items/semantics.rb
@@ -9,7 +9,7 @@ require_relative "semantics/enumerable"
 module OpenHAB
   module Core
     module Items
-      # Module for implementing semantics helper methods on {GenericItem} in order to easily navigate
+      # Module for implementing semantics helper methods on {Item} in order to easily navigate
       # the {https://www.openhab.org/docs/tutorial/model.html Semantic Model} in your scripts.
       # This can be extremely useful to find related items in rules that are executed for any member of a group.
       #
@@ -161,6 +161,7 @@ module OpenHAB
         GenericItem.include(self)
         GroupItem.extend(Forwardable)
         GroupItem.def_delegators :members, :equipments, :locations
+
         # @!parse
         #   class Items::GroupItem
         #     #
@@ -273,7 +274,7 @@ module OpenHAB
         # Checks ancestor groups one level at a time, returning the first
         # {Location} Item found.
         #
-        # @return [GenericItem, nil]
+        # @return [Item, nil]
         #
         def location
           Actions::Semantics.get_location(self)&.then(&Proxy.method(:new))
@@ -299,7 +300,7 @@ module OpenHAB
         #
         # Checks ancestor groups one level at a time, returning the first {Equipment} Item found.
         #
-        # @return [GenericItem, nil]
+        # @return [Item, nil]
         #
         def equipment
           Actions::Semantics.get_equipment(self)&.then(&Proxy.method(:new))
@@ -379,7 +380,7 @@ module OpenHAB
         #   Pass 1 or 2 classes that are sub-classes of {Point} or {Property}.
         #   Note that when comparing against semantic tags, it does a sub-class check.
         #   So if you search for [Control], you'll get items tagged with [Switch].
-        # @return [Array<GenericItem>]
+        # @return [Array<Item>]
         #
         def points(*point_or_property_types)
           return members.points(*point_or_property_types) if equipment? || location?
@@ -403,7 +404,7 @@ module Enumerable
   #
 
   # Returns a new array of items that are a semantics Location (optionally of the given type)
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   def locations(type = nil)
     if type && (!type.is_a?(Module) || !(type < Semantics::Location))
       raise ArgumentError, "type must be a subclass of Location"
@@ -423,7 +424,7 @@ module Enumerable
   #   that belong to the {Semantics::Equipment equipments}, use {#members}
   #   before calling {#points}. See the example with {#points}.
   #
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   #
   # @example Get all TVs in a room
   #   lGreatRoom.equipments(Semantics::Screen)
@@ -440,7 +441,7 @@ module Enumerable
 
   # Returns a new array of items that are semantics points (optionally of a given type)
   #
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   #
   # @example Get all the power switch items for every equipment in a room
   #   lGreatRoom.equipments.members.points(Semantics::Switch)

--- a/lib/openhab/core/items/semantics/enumerable.rb
+++ b/lib/openhab/core/items/semantics/enumerable.rb
@@ -40,31 +40,31 @@ module Enumerable
   #
 
   # Returns a new array of items that have at least one of the given tags
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   def tagged(*tags)
     reject { |i| (tags & i.tags.to_a).empty? }
   end
 
   # Returns a new array of items that do not have any of the given tags
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   def not_tagged(*tags)
     select { |i| (tags & i.tags.to_a).empty? }
   end
 
   # Returns a new array of items that are a member of at least one of the given groups
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   def member_of(*groups)
     reject { |i| (groups.map(&:name) & i.group_names).empty? }
   end
 
   # Returns a new array of items that are not a member of any of the given groups
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   def not_member_of(*groups)
     select { |i| (groups.map(&:name) & i.group_names).empty? }
   end
 
   # Returns the group members the elements
-  # @return [Array<GenericItem>]
+  # @return [Array<Item>]
   def members
     grep(OpenHAB::Core::Items::GroupItem).flat_map(&:members)
   end
@@ -149,6 +149,6 @@ module Enumerable
   # can't use `include`, because Enumerable has already been included
   # in other classes
   def ensure
-    OpenHAB::DSL::Items::Ensure::GenericItemDelegate.new(self)
+    OpenHAB::DSL::Items::Ensure::ItemDelegate.new(self)
   end
 end

--- a/lib/openhab/core/rules/registry.rb
+++ b/lib/openhab/core/rules/registry.rb
@@ -42,7 +42,7 @@ module OpenHAB
         # @return [Object] The result of the block.
         #
         def build(preferred_provider = nil, &block)
-          DSL::Rules::Builder.new(preferred_provider).instance_eval(&block)
+          DSL::Rules::Builder.new(preferred_provider).instance_eval_with_dummy_items(&block)
         end
 
         #

--- a/lib/openhab/core/things/channel.rb
+++ b/lib/openhab/core/things/channel.rb
@@ -9,7 +9,7 @@ module OpenHAB
 
       #
       # {Channel} is a part of a {Thing} that represents a functionality of it.
-      # Therefore {GenericItem Items} can be linked a to a channel.
+      # Therefore {Item Items} can be linked a to a channel.
       #
       # @!attribute [r] item
       #   (see ChannelUID#item)

--- a/lib/openhab/core/things/channel_uid.rb
+++ b/lib/openhab/core/things/channel_uid.rb
@@ -28,7 +28,7 @@ module OpenHAB
         # Return the item if this channel is linked with an item. If a channel is linked to more than one item,
         # this method only returns the first item.
         #
-        # @return [GenericItem, nil]
+        # @return [Item, nil]
         #
         def item
           items.first
@@ -39,7 +39,7 @@ module OpenHAB
         #
         # Returns all of the channel's linked items.
         #
-        # @return [Array<GenericItem>] An array of things or an empty array
+        # @return [Array<Item>] An array of things or an empty array
         #
         def items
           registry = OSGi.service("org.openhab.core.thing.link.ItemChannelLinkRegistry")

--- a/lib/openhab/core/things/item_channel_link.rb
+++ b/lib/openhab/core/things/item_channel_link.rb
@@ -6,7 +6,7 @@ module OpenHAB
       java_import org.openhab.core.thing.link.ItemChannelLink
 
       #
-      # Represents the link between a {GenericItem} and a {Thing Thing's}
+      # Represents the link between an {Item} and a {Thing Thing's}
       # {Channel}.
       #
       # @!attribute [r] thing
@@ -21,7 +21,7 @@ module OpenHAB
         def_delegator :linked_uid, :thing
 
         # @!attribute [r] item
-        # @return [GenericItem]
+        # @return [Item]
         def item
           DSL.items[item_name]
         end

--- a/lib/openhab/core/things/links/provider.rb
+++ b/lib/openhab/core/things/links/provider.rb
@@ -4,11 +4,11 @@ module OpenHAB
   module Core
     module Things
       #
-      # Contains the link between a {Thing Thing's} {Channel Channels} and {GenericItem Items}.
+      # Contains the link between a {Thing Thing's} {Channel Channels} and {Item Items}.
       #
       module Links
         #
-        # Provides {Items::GenericItem items} linked to {Channel channels} in Ruby to openHAB.
+        # Provides {Items::Item items} linked to {Channel channels} in Ruby to openHAB.
         #
         class Provider < Core::Provider
           include org.openhab.core.thing.link.ItemChannelLinkProvider

--- a/lib/openhab/core/things/thing.rb
+++ b/lib/openhab/core/things/thing.rb
@@ -9,7 +9,7 @@ module OpenHAB
       #
       # A {Thing} is a representation of a connected part (e.g. physical device
       # or cloud service) from the real world. It contains a list of
-      # {Channel Channels}, which can be bound to {GenericItem Items}.
+      # {Channel Channels}, which can be bound to {Item Items}.
       #
       # @see OpenHAB::DSL.things things[]
       # @see EntityLookup

--- a/lib/openhab/core_ext/ruby/symbol.rb
+++ b/lib/openhab/core_ext/ruby/symbol.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Extensions to Symbol
+class Symbol
+  # Ruby 3.0 already has #name
+  alias_method :name, :to_s unless instance_methods.include?(:name)
+end

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -69,7 +69,7 @@ module OpenHAB
     #   The state being sent for `:state_from_item` and `:state_from_handler` events.
     # @yieldparam [Core::Things::ItemChannelLink] link
     #   The link between the item and the channel, including its configuration.
-    # @yieldparam [GenericItem] item The linked item.
+    # @yieldparam [Item] item The linked item.
     # @yieldparam [Core::Things::ChannelUID] channel_uid The linked channel.
     # @yieldparam [Hash] configuration The profile configuration.
     # @yieldparam [org.openhab.core.thing.profiles.ProfileContext] context The profile context.
@@ -208,7 +208,7 @@ module OpenHAB
     #
     # When a timer is cancelled, it will be removed from the object.
     #
-    # Be sure that your ids are unique. For example, if you're using {GenericItem items} as your
+    # Be sure that your ids are unique. For example, if you're using {Item items} as your
     # ids, you either need to be sure you don't use the same item for multiple logical contexts,
     # or you need to make your id more specific, by doing something like embedding the item in
     # array with a symbol of the timer's purpose, like `[:vacancy, item]`. But also note that
@@ -342,7 +342,7 @@ module OpenHAB
     # current state of each item. It is implemented by calling OpenHAB's
     # [events.storeStates()](https://www.openhab.org/docs/configuration/actions.html#event-bus-actions).
     #
-    # @param [GenericItem] items Items to store states of.
+    # @param [Item] items Items to store states of.
     #
     # @return [Core::Items::StateStorage] item states
     #
@@ -629,7 +629,7 @@ module OpenHAB
     #   Otherwise it's applied to all types.
     # @param [Hash] providers_by_type
     #     A list of providers by type. Type can be `:items`, `:metadata`, `:things`, `:links`,
-    #     a {GenericItem} applying the provider to all metadata on that item, or a String or Symbol
+    #     an {Item} applying the provider to all metadata on that item, or a String or Symbol
     #     applying the provider to all metadata of that namespace.
     #
     #     The provider can be a {org.openhab.core.common.registry.Provider Provider}, `:persistent`,
@@ -693,7 +693,7 @@ module OpenHAB
           thread_providers[type] = provider
         when Symbol, String
           (thread_providers[:metadata_namespaces] ||= {})[type.to_s] = provider
-        when GenericItem
+        when Item
           (thread_providers[:metadata_items] ||= {})[type.name] = provider
         else
           raise ArgumentError, "#{type.inspect} is not provider type"

--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     #
-    # Contains extensions to simplify working with [GenericItem]s.
+    # Contains extensions to simplify working with {Item Items}.
     #
     module Items
       # An item builder allows you to dynamically create OpenHAB items at runtime.

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -7,7 +7,7 @@ module OpenHAB
     module Items
       # Functionality to implement `ensure`/`ensure_states`
       module Ensure
-        # Contains the `ensure` method mixed into {GenericItem} and {GroupItem::Members}
+        # Contains the `ensure` method mixed into {Item} and {GroupItem::Members}
         module Ensurable
           # Fluent method call that you can chain commands on to, that will
           # then automatically ensure that the item is not in the command's
@@ -18,15 +18,15 @@ module OpenHAB
           # @example Turn on all switches in a group that aren't already on
           #   MySwitchGroup.members.ensure.on
           def ensure
-            GenericItemDelegate.new(self)
+            ItemDelegate.new(self)
           end
         end
 
-        # Extensions for {::GenericItem} to implement {Ensure}'s functionality
+        # Extensions for {::Item} to implement {Ensure}'s functionality
         #
         # @see OpenHAB::DSL.ensure ensure
         # @see OpenHAB::DSL.ensure_states ensure_states
-        module GenericItem
+        module Item
           include Ensurable
 
           Core::Items::GenericItem.prepend(self)
@@ -63,7 +63,7 @@ module OpenHAB
         # "anonymous" class that wraps any method call in `ensure_states`
         # before forwarding to the wrapped object
         # @!visibility private
-        class GenericItemDelegate
+        class ItemDelegate
           def initialize(item)
             @item = item
           end

--- a/lib/openhab/dsl/items/timed_command.rb
+++ b/lib/openhab/dsl/items/timed_command.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Items
-      # Extensions for {GenericItem} to implement timed commands
+      # Extensions for {Item} to implement timed commands
       #
       # All items have an implicit timer associated with them, enabling to
       # easily set an item into a specific state for a specified duration and
@@ -28,7 +28,7 @@ module OpenHAB
         # Provides information about why the expiration block of a
         # {TimedCommand#command timed command} is being called.
         #
-        # @attr [GenericItem] item
+        # @attr [Item] item
         #   @!visibility private
         # @attr [Types::Type, Proc] on_expire
         #   @!visibility private

--- a/lib/openhab/dsl/rules/builder.rb
+++ b/lib/openhab/dsl/rules/builder.rb
@@ -23,6 +23,9 @@ module OpenHAB
       #
       class Builder
         include Terse
+        include Core::EntityLookup
+
+        self.create_dummy_items = true
 
         # @return [org.openhab.core.automation.RuleProvider]
         attr_reader :provider
@@ -119,6 +122,8 @@ module OpenHAB
         prepend Triggers
         extend Property
         extend Forwardable
+
+        self.create_dummy_items = true
 
         delegate %i[triggers trigger_conditions attachments] => :@rule_triggers
 
@@ -800,11 +805,11 @@ module OpenHAB
             case item
             when Core::Things::Thing,
                  Core::Things::ThingUID,
-                 Core::Items::GenericItem,
+                 Core::Items::Item,
                  Core::Items::GroupItem::Members
               nil
             else
-              raise ArgumentError, "items must be a GenericItem, GroupItem::Members, Thing, or ThingUID"
+              raise ArgumentError, "items must be an Item, GroupItem::Members, Thing, or ThingUID"
             end
 
             logger.trace("Creating changed trigger for entity(#{item}), to(#{to.inspect}), from(#{from.inspect})")
@@ -1003,7 +1008,7 @@ module OpenHAB
         # The `event` passed to run blocks will be an
         # {Core::Events::ItemCommandEvent}.
         #
-        # @param [GenericItem, GroupItem::Members] items Items to create trigger for
+        # @param [Item, GroupItem::Members] items Items to create trigger for
         # @param [Core::TypesCommand, Array<Command>, Range, Proc] command commands to match for trigger
         # @param [Array<Command>, Range, Proc] commands Fluent alias for `command`
         # @param [Object] attach object to be attached to the trigger
@@ -1075,11 +1080,11 @@ module OpenHAB
 
           items.each do |item|
             case item
-            when Core::Items::GenericItem,
+            when Core::Items::Item,
                  Core::Items::GroupItem::Members
               nil
             else
-              raise ArgumentError, "items must be a GenericItem or GroupItem::Members"
+              raise ArgumentError, "items must be an Item or GroupItem::Members"
             end
             commands.each do |cmd|
               logger.trace "Creating received command trigger for items #{item.inspect} and commands #{cmd.inspect}"
@@ -1197,7 +1202,7 @@ module OpenHAB
         # {Core::Events::ThingStatusInfoEvent} depending on if the triggering
         # element was an item or a thing.
         #
-        # @param [GenericItem, GroupItem::Members, Thing] items
+        # @param [Item, GroupItem::Members, Thing] items
         #   Objects to create trigger for.
         # @param [State, Array<State>, Range, Proc, Symbol, String] to
         #   Only execute rule if the state matches `to` state(s). If the
@@ -1274,11 +1279,11 @@ module OpenHAB
             case item
             when Core::Things::Thing,
                  Core::Things::ThingUID,
-                 Core::Items::GenericItem,
+                 Core::Items::Item,
                  Core::Items::GroupItem::Members
               nil
             else
-              raise ArgumentError, "items must be a GenericItem, GroupItem::Members, Thing, or ThingUID"
+              raise ArgumentError, "items must be an Item, GroupItem::Members, Thing, or ThingUID"
             end
 
             logger.trace("Creating updated trigger for item(#{item}) to(#{to})")
@@ -1378,17 +1383,6 @@ module OpenHAB
         # @!visibility private
         def start_attachment
           @on_start.attach
-        end
-
-        # @!visibility private
-        #
-        # Run the supplied block inside the object instance of the object that created the rule
-        #
-        # @yield [] Block executed in context of the object creating the rule
-        #
-        #
-        def my(&block)
-          @caller.instance_eval(&block)
         end
 
         #

--- a/lib/openhab/dsl/rules/triggers/changed.rb
+++ b/lib/openhab/dsl/rules/triggers/changed.rb
@@ -160,7 +160,7 @@ module OpenHAB
           #  second element is a Hash configuring trigger
           #
           def group(group:, from:, to:)
-            config = { "groupName" => group.group.name }
+            config = { "groupName" => group.name }
             config["state"] = to.to_s if to
             config["previousState"] = from.to_s if from
             [GROUP_STATE_CHANGE, config]

--- a/lib/openhab/dsl/things/builder.rb
+++ b/lib/openhab/dsl/things/builder.rb
@@ -133,7 +133,7 @@ module OpenHAB
         #   it will be deducible from the `uid` if it contains two or more segments.
         #   To create a Thing with a blank type id, use one segment for `uid` and provide the binding id.
         # @param [String, BridgeBuilder] bridge The bridge uid, if the Thing should belong to a bridge.
-        # @param [String, GenericItem] location The location of this Thing.
+        # @param [String, Item] location The location of this Thing.
         #   When given an Item, use the item's label as the location.
         # @param [Hash] config The Thing's configuration, as required by the binding. The key can be strings or symbols.
         # @param [true,false] enabled Whether the Thing should be enabled or disabled.
@@ -169,7 +169,7 @@ module OpenHAB
           @thing_type_uid = org.openhab.core.thing.ThingTypeUID.new(*@uid.all_segments[0..1])
           @label = label
           @location = location
-          @location = location.label if location.is_a?(GenericItem)
+          @location = location.label if location.is_a?(Item)
           @config = config.transform_keys(&:to_s)
           @enabled = enabled
         end

--- a/spec/openhab/core/items/item_spec.rb
+++ b/spec/openhab/core/items/item_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe OpenHAB::Core::Items::GenericItem do
+RSpec.describe OpenHAB::Core::Items::Item do
   before do
     items.build do
       group_item "House" do

--- a/spec/openhab/core/items/proxy_spec.rb
+++ b/spec/openhab/core/items/proxy_spec.rb
@@ -48,6 +48,32 @@ RSpec.describe OpenHAB::Core::Items::Proxy do
     expect(original.__getobj__).to be new_item.__getobj__
   end
 
+  context "without a backing item" do
+    let(:item) { described_class.new(:MySwitch) }
+
+    it "supports #name" do
+      expect(item.name).to eq "MySwitch"
+    end
+
+    it "pretends to be an item" do
+      expect(item).to be_a(Item)
+    end
+
+    it "can access GroupItem#members" do
+      expect(item.members).to be_a(GroupItem::Members)
+    end
+
+    it "doesn't respond to other Item methods" do
+      expect(item).not_to respond_to(:command)
+      expect { item.command }.to raise_error(NoMethodError)
+    end
+  end
+
+  it "does not respond to GroupItem#members if it's backed by a non-GroupItem" do
+    expect(Switch1).not_to respond_to(:members)
+    expect { Switch1.members }.to raise_error(NoMethodError)
+  end
+
   describe "Comparisons" do
     before do
       items.build { switch_item "Switch2" }

--- a/spec/openhab/dsl/rules/builder_spec.rb
+++ b/spec/openhab/dsl/rules/builder_spec.rb
@@ -376,6 +376,51 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
             test_changed_trigger("Switches", from: ON, to: ON, expect_triggered: nil)
           end
         end
+
+        context "with dummy proxies" do
+          it "handles items that are constants" do
+            triggered = false
+            rule do
+              changed ItemThatDoesntYetExist
+              run { triggered = true }
+            end
+
+            items.build { switch_item "ItemThatDoesntYetExist" }
+            expect(triggered).to be false
+            ItemThatDoesntYetExist.on
+            expect(triggered).to be true
+          end
+
+          it "handles items that are not constants" do
+            triggered = false
+            rule do
+              changed gItemThatDoesntYetExist
+              run { triggered = true }
+            end
+
+            items.build { switch_item "gItemThatDoesntYetExist" }
+            expect(triggered).to be false
+            gItemThatDoesntYetExist.on
+            expect(triggered).to be true
+          end
+
+          it "handles group members" do
+            triggered = false
+            rule do
+              changed gItemThatDoesntYetExist.members
+              run { triggered = true }
+            end
+
+            items.build do
+              group_item "gItemThatDoesntYetExist", type: :switch, function: "OR(ON,OFF)" do
+                switch_item "Switch2"
+              end
+            end
+            expect(triggered).to be false
+            Switch2.on
+            expect(triggered).to be true
+          end
+        end
       end
 
       context "with things" do


### PR DESCRIPTION
so that it behaves just like the DSL, and may help to prevent errors loading rules out-of-order.