### PR TITLE
don't do entity lookup on method calls

### DIFF
--- a/lib/openhab/core/entity_lookup.rb
+++ b/lib/openhab/core/entity_lookup.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "ruby2_keywords"
+
 module OpenHAB
   module Core
     #
@@ -48,7 +50,9 @@ module OpenHAB
       #
       # @return [Item, Things::Thing, nil]
       #
-      def method_missing(method, *)
+      ruby2_keywords def method_missing(method, *args)
+        return super unless args.empty? && !block_given?
+
         logger.trace("method missing, performing openHAB Lookup for: #{method}")
         EntityLookup.lookup_entity(method,
                                    create_dummy_items: self.class.respond_to?(:create_dummy_items?) &&

--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -469,6 +469,8 @@ module OpenHAB
         include Builder
 
         Builder.public_instance_methods.each do |m|
+          next unless Builder.instance_method(m).owner == Builder
+
           class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def #{m}(*args, groups: nil, **kwargs)  # def dimmer_item(*args, groups: nil, **kwargs)
               groups ||= []                         #   groups ||= []

--- a/spec/openhab/core/items/item_spec.rb
+++ b/spec/openhab/core/items/item_spec.rb
@@ -163,4 +163,18 @@ RSpec.describe OpenHAB::Core::Items::Item do
     expect(Switch1).not_to eq Switch2
     expect(Switch1).not_to eq Switch3
   end
+
+  describe "entity lookup" do
+    it "doesn't confuse a method call with an item" do
+      items.build { group_item "gGroup" }
+
+      expect(gGroup).to be_a(GroupItem)
+      expect { gGroup(:argument) }.to raise_error(NoMethodError)
+      expect do
+        gGroup do
+          nil
+        end
+      end.to raise_error(NoMethodError)
+    end
+  end
 end


### PR DESCRIPTION
this especially helps when dummy item lookup is enabled