### PR TITLE
rearrange document sections into a more logical order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,69 +6,13 @@
 [![EPLv2 License](https://img.shields.io/badge/License-EPLv2-blue.svg)](https://www.eclipse.org/legal/epl-2.0/)
 
 This library aims to be a fairly high-level Ruby gem to support automation in openHAB.
+It provides native Ruby access to common openHAB functionality within rules including items, things, actions, logging and more.
 
 Full documentation is available on [GitHub Pages](https://ccutrer.github.io/openhab-jrubyscripting/).
 
- * [Usage](USAGE.md)
- * [Changelog](CHANGELOG.md)
- * [Contributing](CONTRIBUTING.md)
-
-## Installation
-
-### Prerequisites
-
-1. openHAB 3.3+
-2. The JRuby Scripting Language Addon
-
-### From the User Interface
-
-1. Go to `Settings -> Add-ons -> Automation` and install the jrubyscripting automation addon following the [openHAB instructions](https://www.openhab.org/docs/configuration/addons.html)
-2. Go to `Settings -> Other Services -> JRuby Scripting`:
-   * **Ruby Gems**: `openhab-jrubyscripting=~>5.0`
-   * **Require Scripts**: `openhab/dsl` (not required, but recommended)
-
-### Using Files
-
-1. Edit `<OPENHAB_CONF>/services/addons.cfg` and ensure that `jrubyscripting` is included in an uncommented `automation=` list of automations to install.  
-2. Optionally configure JRuby openHAB services
-   
-   Create a file called `jruby.cfg` in `<OPENHAB_CONF>/services/` with the following content:
-   ```
-   org.openhab.automation.jrubyscripting:gems=openhab-jrubyscripting=~>5.0
-   org.openhab.automation.jrubyscripting:require=openhab/dsl
-   ```
-
-   This configuration with the openhab-jrubyscripting gem specified with [pessimistic versioning](https://thoughtbot.com/blog/rubys-pessimistic-operator) will install any version of openhab-jrubyscripting greater than or equal to 5.0 but less than 6.0.
-   On system restart if any (non-breaking) new versions of the library are available they will automatically be installed.
-
-### Upgrading
-
-Depending on the versioning selected in the `jruby.cfg` or the gems list in the user interface, file upgrading will either be automatic after a openHAB restart or manual.
-For manual upgrades select the version of the gem exactly, for example, `org.openhab.automation.jrubyscripting:gems=openhab-jrubyscripting=5.0.0` will install and stay at version 5.0.0.
-To upgrade to version 5.0.1, change the configuration: `org.openhab.automation.jrubyscripting:gems=openhab-jrubyscripting=5.0.1`.
-To automatically upgrade, it is recommended to use pessimistic versioning: `org.openhab.automation.jrubyscripting:gems=openhab-jrubyscripting=~>5.0`/
-This will install at least version 5.0 and on every restart will automatically install any version that is less than 6.0.
-This ensures that fixes and new features are available without introducing any breaking changes.
-
-## Design points
-- Create an intuitive method of defining rules and automation
-	- Rule language should "flow" in a way that you can read the rules out loud
-- Abstract away complexities of openHAB
-- Enable all the power of Ruby and openHAB
-- Create a Frictionless experience for building automation
-- The common, yet tricky tasks are abstracted and made easy. e.g. Running a rule between only certain hours of the day
-- Tested
-	- Designed and tested using [Test-Driven Development](https://en.wikipedia.org/wiki/Test-driven_development) with [RSpec](https://rspec.info/)
-- Extensible
-	- Anyone should be able to customize and add/remove core language features
-- Easy access to the Ruby ecosystem in rules through Ruby gems. 
-
-## Why Ruby?
-- Ruby is designed for programmer productivity with the idea that programming should be fun for programmers.
-- Ruby emphasizes the necessity for software to be understood by humans first and computers second.
-- For me, automation is a hobby, I want to enjoy writing automation not fight compilers and interpreters .
-- Rich ecosystem of tools, including things like Rubocop to help developers write clean code and RSpec to test the libraries.
-- Ruby is really good at letting one express intent and creating a DSL within Ruby to make that expression easier.
+* [Usage](USAGE.md)
+* [Changelog](CHANGELOG.md)
+* [Contributing](CONTRIBUTING.md)
 
 ## Fork from [openhab-scripting](https://github.com/boc-tothefuture/openhab-jruby/)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 # Examples
 
-The following examples are for file-based rules but most of them are applicable to [GUI rules](../USAGE.md#ui-based-scripts) as well.
+The following examples are for file-based rules but most of them are applicable to [UI rules](../USAGE.md#ui-based-scripts) as well.
 
 ## Trigger when an item changed state
 
@@ -38,7 +38,7 @@ rule 'Control light based on door state' do
 end
 ```
 
-## Trigger when a group member changed state:
+## Trigger when a group member changed state
 
 ```ruby
 # Assumption: Motion sensor items are named using the pattern RoomName_Motion
@@ -79,7 +79,7 @@ ColorItem1.command {r: 255, g: 0xFF, b: 0}
 ```
 
 Each item type supports command helpers relevant to the type.
-For example, a {SwitchItem} supports {SwitchItem#on on} and {SwitchItem#off off}. 
+For example, a {SwitchItem} supports {SwitchItem#on on} and {SwitchItem#off off}.
 See specific item types under {OpenHAB::Core::Items}
 
 ## Dealing with Item States


### PR DESCRIPTION
I've moved "Why Ruby" into USAGE because that is more important for those who read the addon document than for someone who's looking at the github repo.

I've also re-ordered the sections to put Rules first, then Items, the two most important concepts that people would most likely want to see first, before delving into the nitty gritty of the other stuff.

