### PR TITLE
cosmetic fix for the summary toggle link

### DIFF
--- a/templates/default/fulldoc/html/css/common.css
+++ b/templates/default/fulldoc/html/css/common.css
@@ -144,6 +144,10 @@ footer {
     top: -1px;
 }
 
+small .summary_toggle { 
+    padding: 5px 7px; 
+}
+
 img {
     max-width: 100%;
 }
@@ -191,7 +195,7 @@ img {
     .note { color: #ccc; border-color: #444; }
     .note.todo { background: #2f353c; border-color: #444; }
     .note.returns_void { background: #2f353c; }
-    .note.deprecated { background: #2f353c; border-color: ##444; }
+    .note.deprecated { background: #2f353c; border-color: #444; }
     .note.title.deprecated { background: #2f353c; border-color: #444; }
     .note.private { background: #2f353c; border-color: #444; }
     .note.title { background: #2f353c; }


### PR DESCRIPTION
The expand/collapse gap

<img width="572" alt="image" src="https://user-images.githubusercontent.com/2554958/206824495-c1b93548-55ec-405d-bb9f-b9a22b5d1088.png">
 to:

<img width="568" alt="image" src="https://user-images.githubusercontent.com/2554958/206824513-9cfa80e6-0800-4803-90d7-53bdef8a11f3.png">
