### PR TITLE
make automation paths configurable in rspec

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,6 +80,12 @@ and then load rules in, then drop you into IRB.
 
 ### Spec Writing Tips
 
+ * By default ruby files are looked for in `$OPENHAB_CONF/automation/ruby` and in `$OPENHAB_CONF/automation/jsr223`. You can override and/or append to this by setting the `openhab_automation_search_paths` RSpec configuration setting in your `spec_helper.rb`. This can be useful to add staging directory for testing your rules.
+ ```ruby
+RSpec.configure do |config|
+  config.openhab_automation_search_paths += "/my/staging/directory"
+end
+ ```
  * See {OpenHAB::RSpec::Helpers} for all helper methods available in specs.
  * All items are reset to {NULL} before each spec.
  * `on_load` triggers are _not_ honored. Items will be reset to {NULL} before

--- a/lib/openhab/rspec.rb
+++ b/lib/openhab/rspec.rb
@@ -19,6 +19,6 @@ require_relative "rspec/hooks"
 RSpec.configure do |c|
   c.add_setting :openhab_automation_search_paths, default: [
     "#{org.openhab.core.OpenHAB.config_folder}/automation/ruby",
-    "#{org.openhab.core.OpenHAB.config_folder}/automation/jsr223/ruby/personal"
+    "#{org.openhab.core.OpenHAB.config_folder}/automation/jsr223"
   ]
 end

--- a/lib/openhab/rspec.rb
+++ b/lib/openhab/rspec.rb
@@ -15,3 +15,10 @@ require_relative "rspec/configuration"
 require_relative "rspec/helpers"
 require_relative "rspec/karaf"
 require_relative "rspec/hooks"
+
+RSpec.configure do |c|
+  c.add_setting :openhab_automation_search_paths, default: [
+    "#{org.openhab.core.OpenHAB.config_folder}/automation/ruby",
+    "#{org.openhab.core.OpenHAB.config_folder}/automation/jsr223/ruby/personal"
+  ]
+end

--- a/lib/openhab/rspec/helpers.rb
+++ b/lib/openhab/rspec/helpers.rb
@@ -265,12 +265,13 @@ module OpenHAB
       # @return [void]
       #
       def load_rules
-        automation_path = "#{org.openhab.core.OpenHAB.config_folder}/automation/ruby"
+        automation_paths = Array(::RSpec.configuration.openhab_automation_search_paths)
+
         lib_dirs = rubylib_dirs.map { |d| File.join(d, "") }
         lib_dirs << File.join(gem_home, "")
 
         SuspendRules.suspend_rules do
-          files = Dir["#{automation_path}/**/*.rb"]
+          files = automation_paths.map { |p| Dir["#{p}/**/*.rb"] }.flatten
           files.reject! do |f|
             lib_dirs.any? { |l| f.start_with?(l) }
           end

--- a/spec/openhab/rspec/helpers_spec.rb
+++ b/spec/openhab/rspec/helpers_spec.rb
@@ -4,8 +4,10 @@
 RSpec.describe OpenHAB::RSpec::Helpers do
   describe "load_rules" do
     it "respects start levels" do
+      allow(::RSpec.configuration).to receive(:openhab_automation_search_paths).and_return(["automation"])
       allow(Dir).to receive(:[]).and_return(%w[automation/filea.rb automation/sl30/filec.rb
                                                automation/filea.sl20.rb automation/sl30/fileb.rb])
+
       # rubocop:disable RSpec/SubjectStub
       expect(subject).to receive(:load).with("automation/filea.sl20.rb").ordered
       expect(subject).to receive(:load).with("automation/sl30/fileb.rb").ordered


### PR DESCRIPTION
automation paths can be configured in the rspec helper file by adding config.openhab_automation_search_paths. The default is to check OPENHAB_CONF/automation/ruby and
OPENHAB_CONF/automation/jsr223/ruby/personal