### PR TITLE
Docs scroll padding

### DIFF
--- a/templates/default/fulldoc/html/css/common.css
+++ b/templates/default/fulldoc/html/css/common.css
@@ -1,7 +1,3 @@
-html {
-    scroll-padding-top: 70px;
-}
-
 @media (min-width: 860px) {
     html {
         font-size: .938em;

--- a/templates/default/fulldoc/html/css/common.css
+++ b/templates/default/fulldoc/html/css/common.css
@@ -1,3 +1,7 @@
+html {
+    scroll-padding-top: 70px;
+}
+
 @media (min-width: 860px) {
     html {
         font-size: .938em;

--- a/templates/default/fulldoc/html/css/navbar.css
+++ b/templates/default/fulldoc/html/css/navbar.css
@@ -9,6 +9,10 @@
     line-height: 2.2rem;
 }
 
+html {
+    scroll-padding-top: 4.4rem;
+}
+
 .navbar .logo {
     height: 2.2rem;
     min-width: 2.2rem;

--- a/templates/default/fulldoc/html/css/sidebar.css
+++ b/templates/default/fulldoc/html/css/sidebar.css
@@ -177,6 +177,7 @@ span.sidebar-link.active a {
     display: inline-block;
     width: 0;
     height: 0;
+    cursor: pointer;
 }
 
 .arrow.down, .arrow.up {


### PR DESCRIPTION
When clicking on an in-page links, the page would scroll/jump to the in-page target but the top was hidden by the navbar.

Before:

<img width="451" alt="image" src="https://user-images.githubusercontent.com/2554958/206885031-cb07f277-4c56-4067-bf02-64b699b1734b.png">


after:

<img width="579" alt="image" src="https://user-images.githubusercontent.com/2554958/206885005-2c11a50c-916e-48df-8de7-25161e6fb812.png">
