### PR TITLE
add delay option to on_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ here is a non-exhaustive list of significant departures from the original gem:
   Note that this only works for {OpenHAB::DSL::Rules::Terse terse rules} if they're created within a {OpenHAB::DSL::Rules::Builder rules.build} block.
 * {OpenHAB::DSL::Rules::BuilderDSL#on_start #on_start} supports creating a `core.SystemStartlevelTrigger`.
   Also see {OpenHAB::DSL::Rules::BuilderDSL#on_load #on_load}.
+* {OpenHAB::DSL::Rules::BuilderDSL#on_load #on_load} supports delay
 * Various Ephemeris methods on {ZonedDateTime}.
 
 ### Bug Fixes

--- a/lib/openhab/dsl/rules/builder.rb
+++ b/lib/openhab/dsl/rules/builder.rb
@@ -541,7 +541,7 @@ module OpenHAB
           @rule_triggers = RuleTriggers.new
           @caller = caller_binding.eval "self"
           @ruby_triggers = []
-          @on_load_id = nil
+          @on_load = nil
           enabled(true)
           tags([])
         end
@@ -976,6 +976,8 @@ module OpenHAB
         # and on subsequent reloads on file modifications.
         # This is useful to perform initialization routines, especially when combined with other triggers.
         #
+        # @param [Duration] delay The amount of time to wait before executing the rule.
+        #   When nil, execute immediately.
         # @param [Object] attach Object to be attached to the trigger
         # @return [void]
         #
@@ -993,12 +995,12 @@ module OpenHAB
         #     run { Security_Lights.on }
         #   end
         #
-        def on_load(attach: nil)
-          # prevent overwriting @on_load_id
-          raise ArgumentError, "on_load can only be used once within a rule" if @on_load_id
+        def on_load(delay: nil, attach: nil)
+          # prevent overwriting @on_load
+          raise ArgumentError, "on_load can only be used once within a rule" if @on_load
 
-          @on_load_id = SecureRandom.uuid
-          attachments[@on_load_id] = attach
+          @on_load = { module: SecureRandom.uuid, delay: delay }
+          attachments[@on_load[:module]] = attach
         end
 
         #
@@ -1445,7 +1447,7 @@ module OpenHAB
             #<OpenHAB::DSL::Rules::Builder: #{uid}
             triggers=#{triggers.inspect},
             run blocks=#{run.inspect},
-            on_load=#{!@on_load_id.nil?},
+            on_load=#{!@on_load.nil?},
             Trigger Conditions=#{trigger_conditions.inspect},
             Trigger UIDs=#{triggers.map(&:id).inspect},
             Attachments=#{attachments.inspect}
@@ -1468,11 +1470,25 @@ module OpenHAB
           added_rule.actions.first.configuration.put("type", "application/x-ruby")
           added_rule.actions.first.configuration.put("script", script) if script
 
-          rule.execute(nil, { "module" => @on_load_id }) if @on_load_id
+          process_on_load { |module_id| rule.execute(nil, { "module" => module_id }) }
+
           added_rule
         end
 
         private
+
+        # Calls the on_load block, with a delay if specified
+        # @yield block to execute on load time
+        # @yieldparam [String] module The module ID that identifies this on_load event
+        def process_on_load
+          return unless @on_load
+
+          if @on_load[:delay]
+            after(@on_load[:delay]) { yield @on_load[:module] }
+          else
+            yield @on_load[:module]
+          end
+        end
 
         # delegate to the caller's logger
         def logger
@@ -1505,7 +1521,7 @@ module OpenHAB
         # @return [true,false] True if rule has triggers, false otherwise
         #
         def triggers?
-          @on_load_id || !triggers.empty?
+          !(@on_load.nil? && triggers.empty?)
         end
 
         #

--- a/spec/openhab/dsl/rules/builder_spec.rb
+++ b/spec/openhab/dsl/rules/builder_spec.rb
@@ -70,6 +70,28 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
       end
     end
 
+    describe "#on_load" do
+      it "works" do
+        executed = false
+        rule do
+          on_load
+          run { executed = true }
+        end
+        expect(executed).to be true
+      end
+
+      it "can use a delay" do
+        executed = false
+        rule do
+          on_load delay: 500.ms
+          run { executed = true }
+        end
+        expect(executed).to be false
+        time_travel_and_execute_timers(800.ms)
+        expect(executed).to be true
+      end
+    end
+
     describe "#on_start" do
       it "works with default level" do
         rule = rule do


### PR DESCRIPTION
I know that there's a delay run block. However, when having one rule with multiple triggers, one of which is an on_load, it is handy to be able to put a delay for on_load whilst not having a delay for other triggers.

Currently this has to be done using the attach feature, with some extra logic inside the rule.
