### PR TITLE
fix timed_command on items with autoupdate=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ here is a non-exhaustive list of significant departures from the original gem:
 * {OpenHAB::DSL::Items::TimedCommand#command Timed command} now resets the on_expire setting when called again
 * {OpenHAB::DSL::Items::TimedCommand#command Timed command} still sends the command even the previous timed command is still pending
 * {OpenHAB::DSL::Items::TimedCommand#command Timed command} works with resetting to {NULL}/{UNDEF}
+* {OpenHAB::DSL::Items::TimedCommand#command Timed command} works on items with autoupdate=false
 * {OpenHAB::Core::Items::Metadata} hashes are indifferent (converts symbol keys to string keys).
 * Fix {OpenHAB::DSL::Items::Ensure ensure} to work with conversions-from-string that are handled by openhab-core.
 * Avoid stack overflow issues when all of ActiveSupport is required.


### PR DESCRIPTION
The problem: 
My items are mqtt based with autoupdate=false. When I send a command to the item, it sends it out via mqtt, but doesn't immediately updates its state. Its state only gets updated by an incoming MQTT message from the device.

Meanwhile, the timed command had already set its change detection rule. When the state update (for the original command) came back from MQTT, it fired the change detection rule which cancels the timed command.

This PR prevents that by restricting the change detection rule to trigger only when the previousState == command, so it would not be triggered by this initial change of state caused by the timed command itself.

~~There is still another edge case that this PR doesn't address:~~
~~- When you issued a timed command from one rule, e.g. Item1.on for: 5.minutes~~
~~- Another rule issued Item1.on afterwards~~

~~You'd probably expect that the timed command is cancelled, and Item1 would stay on. I don't think it's the case right now. An additional received_command trigger is needed.~~

The edge case above has been addressed in this PR too