### PR TITLE
ci: use jruby 9.3.9, not 9.3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       matrix:
         openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
         java_version:  ${{ fromJson(needs.openhab-matrix.outputs.java_matrix) }}
-        jruby_version: ["jruby-9.3.8.0", "jruby-9.4.0.0"]
+        jruby_version: ["jruby-9.3.9.0", "jruby-9.4.0.0"]
         exclude:
           - openhab_version: 3.3.0
             jruby_version: jruby-9.4.0.0


### PR DESCRIPTION
since that's what's in openHAB