### PR TITLE
remove openhab4-snapshot from ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["3.3.0", "3.4.0", "4.0.0-SNAPSHOT"]
+        ["3.3.0", "3.4.0"]
       java_matrix: |
         ["11", "17"]
       snapshot_date: |


### PR DESCRIPTION
Remove openhab4 from ci build for the time being. Cucumber tests are failing due to some authentication errors. 