### PR TITLE
fix changed duration when only from state is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@ here is a non-exhaustive list of significant departures from the original gem:
 * Fix {OpenHAB::DSL::Items::Ensure ensure} to work with conversions-from-string that are handled by openhab-core.
 * Avoid stack overflow issues when all of ActiveSupport is required.
 * Don't swallow exceptions inside of `rule` blocks - just let them propagate up.
+* Fix changed duration when only the `from` state is given
 
 ## [4.45.2](https://github.com/boc-tothefuture/openhab-jruby/compare/4.45.1...4.45.2) (2022-10-02)
 

--- a/lib/openhab/dsl/rules/triggers/conditions/duration.rb
+++ b/lib/openhab/dsl/rules/triggers/conditions/duration.rb
@@ -96,7 +96,7 @@ module OpenHAB
                 yield
               end
               rule.on_removal(self)
-              @tracking_to, = retrieve_states(inputs)
+              _, @tracking_from = retrieve_states(inputs)
             end
 
             #
@@ -106,12 +106,11 @@ module OpenHAB
             # @param [Hash] mod rule trigger mods
             #
             def process_active_timer(inputs, mod, &block)
-              state, = retrieve_states(inputs)
-              if state == @tracking_to
-                logger.trace("Item changed to #{state} for #{self}, rescheduling timer.")
-                @timer.reschedule(@duration)
+              new_state, old_state = retrieve_states(inputs)
+              if new_state != @tracking_from && @conditions.check_to(inputs: {})
+                logger.trace("Item changed from #{old_state} to #{new_state} for #{self}, keep waiting.")
               else
-                logger.trace("Item changed to #{state} for #{self}, canceling timer.")
+                logger.trace("Item changed from #{old_state} to #{new_state} for #{self}, canceling timer.")
                 @timer.cancel
                 # Reprocess trigger delay after canceling to track new state (if guards matched, etc)
                 process(mod: mod, inputs: inputs, &block)

--- a/spec/openhab/dsl/rules/builder_spec.rb
+++ b/spec/openhab/dsl/rules/builder_spec.rb
@@ -404,6 +404,64 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
             expect(triggered_item).to be_nil
           end
 
+          context "without to state" do
+            test_changed_trigger(from: 8) do
+              Alarm_Mode1.update(10)
+              time_travel_and_execute_timers(4.seconds)
+              expect(triggered_item).to be_nil
+              time_travel_and_execute_timers(2.seconds)
+              expect(triggered_item).to eql "Alarm_Mode1"
+            end
+
+            context "when state changes more than once" do # rubocop:disable RSpec/EmptyExampleGroup examples are dynamically generated
+              test_changed_trigger(from: 8) do
+                Alarm_Mode1.update(10)
+                time_travel_and_execute_timers(4.seconds)
+                expect(triggered_item).to be_nil
+                Alarm_Mode1.update(20)
+                execute_timers
+                expect(triggered_item).to be_nil
+                time_travel_and_execute_timers(2.seconds)
+                expect(triggered_item).to eql "Alarm_Mode1"
+              end
+
+              test_changed_trigger(from: [7, 8]) do
+                Alarm_Mode1.update(10)
+                time_travel_and_execute_timers(4.seconds)
+                expect(triggered_item).to be_nil
+                Alarm_Mode1.update(20)
+                execute_timers
+                expect(triggered_item).to be_nil
+                time_travel_and_execute_timers(2.seconds)
+                expect(triggered_item).to eql "Alarm_Mode1"
+              end
+            end
+
+            context "when state changes back to the from state" do # rubocop:disable RSpec/EmptyExampleGroup examples are dynamically generated
+              test_changed_trigger(from: 8) do
+                Alarm_Mode1.update(10)
+                time_travel_and_execute_timers(4.seconds)
+                expect(triggered_item).to be_nil
+                Alarm_Mode1.update(8) # reverts back to from state, it should cancel the trigger
+                execute_timers
+                expect(triggered_item).to be_nil
+                time_travel_and_execute_timers(2.seconds)
+                expect(triggered_item).to be_nil
+              end
+
+              test_changed_trigger(from: [7, 8]) do
+                Alarm_Mode1.update(10)
+                time_travel_and_execute_timers(4.seconds)
+                expect(triggered_item).to be_nil
+                Alarm_Mode1.update(8) # reverts back to from state, it should cancel the trigger
+                execute_timers
+                expect(triggered_item).to be_nil
+                time_travel_and_execute_timers(2.seconds)
+                expect(triggered_item).to be_nil
+              end
+            end
+          end
+
           context "with a numeric group item" do # rubocop:disable RSpec/EmptyExampleGroup examples are dynamically generated
             before do
               items.build do


### PR DESCRIPTION
The bug: `changed(NumberItem1, from: 1, for: 5.minutes)` didn't work when item changed from `1` -> `2` -> `3`. It should still trigger, because technically it has changed from `1` and hasn't reverted back to `1`.

Compare it with a non duration trigger `changed(NumberItem1, from: 1)` which will cause a trigger when it changed from `1` admittedly the subsequent changes are irrelevant because of the instantaneous nature of the trigger.

