### PR TITLE
allow LocalTime.parse to accept a formatter

### DIFF
--- a/lib/openhab/core/actions/exec.rb
+++ b/lib/openhab/core/actions/exec.rb
@@ -4,47 +4,47 @@ module OpenHAB
   module Core
     module Actions
       # @see https://www.openhab.org/docs/configuration/actions.html#exec-actions Exec Actions
-      class Exec
-        class << self # rubocop:disable Lint/EmptyClass
-          # @!method execute_command_line
-          #
-          # @return [void]
-          #
-          # @overload execute_command_line(command_line)
-          #
-          #   Executes a command on the command line without waiting for the
-          #   command to complete.
-          #
-          #   @param [String] command_line
-          #   @return [void]
-          #
-          #   @example Execute an external command
-          #     rule 'Run a command' do
-          #       every :day
-          #       run do
-          #         Exec.execute_command_line('/bin/true')
-          #       end
-          #     end
-          #
-          # @overload execute_command_line(timeout, command_line)
-          #
-          #   Executes a command on the command and waits timeout seconds for
-          #   the command to complete, returning the output from the command
-          #   as a String.
-          #
-          #   @param [Duration] timeout
-          #   @param [String] command_line
-          #   @return [String]
-          #
-          #   @example Execute an external command and process its results
-          #     rule 'Run a command' do
-          #       every :day
-          #       run do
-          #         TodaysHoliday_String.update(Exec.execute_command_line(5.seconds, '/home/cody/determine_holiday.rb')
-          #       end
-          #     end
-          #
-        end
+      class Exec # rubocop:disable Lint/EmptyClass
+        # @!scope class
+
+        # @!method execute_command_line
+        #
+        # @return [void]
+        #
+        # @overload execute_command_line(command_line)
+        #
+        #   Executes a command on the command line without waiting for the
+        #   command to complete.
+        #
+        #   @param [String] command_line
+        #   @return [void]
+        #
+        #   @example Execute an external command
+        #     rule 'Run a command' do
+        #       every :day
+        #       run do
+        #         Exec.execute_command_line('/bin/true')
+        #       end
+        #     end
+        #
+        # @overload execute_command_line(timeout, command_line)
+        #
+        #   Executes a command on the command and waits timeout seconds for
+        #   the command to complete, returning the output from the command
+        #   as a String.
+        #
+        #   @param [Duration] timeout
+        #   @param [String] command_line
+        #   @return [String]
+        #
+        #   @example Execute an external command and process its results
+        #     rule 'Run a command' do
+        #       every :day
+        #       run do
+        #         TodaysHoliday_String.update(Exec.execute_command_line(5.seconds, '/home/cody/determine_holiday.rb')
+        #       end
+        #     end
+        #
       end
     end
   end

--- a/lib/openhab/core/rules.rb
+++ b/lib/openhab/core/rules.rb
@@ -13,7 +13,7 @@ module OpenHAB
 
       class << self
         #
-        # @!attribute [r] rule_manager
+        # @!attribute [r] manager
         # @return [org.openhab.core.automation.RuleManager] The openHAB rule manager/engine
         #
         def manager

--- a/lib/openhab/core_ext/java/local_date.rb
+++ b/lib/openhab/core_ext/java/local_date.rb
@@ -13,10 +13,18 @@ module OpenHAB
         include Between
         include Ephemeris
 
-        class << self # rubocop:disable Lint/EmptyClass
-          # @!attribute [r] now
-          #   @return [ZonedDateTime]
-        end
+        # @!scope class
+
+        # @!attribute [r] now
+        #   @return [LocalDate]
+
+        # @!method parse(text, formatter=nil)
+        #   Converts the given text into a LocalDate.
+        #   @param [String] text The text to parse
+        #   @param [java.time.format.DateTimeFormatter] formatter The formatter to use
+        #   @return [LocalDate]
+
+        # @!scope instance
 
         # @param [TemporalAmount, LocalDate, Numeric] other
         #   If other is a Numeric, it's interpreted as days.

--- a/lib/openhab/core_ext/java/local_date.rb
+++ b/lib/openhab/core_ext/java/local_date.rb
@@ -7,7 +7,7 @@ module OpenHAB
     module Java
       java_import java.time.LocalDate
 
-      # Extensions to LocalDate
+      # Extensions to {java.time.LocalDate}
       class LocalDate
         include Time
         include Between

--- a/lib/openhab/core_ext/java/local_time.rb
+++ b/lib/openhab/core_ext/java/local_time.rb
@@ -8,6 +8,8 @@ module OpenHAB
       java_import java.time.LocalTime
 
       #
+      # Extensions to {java.time.LocalTime}
+      #
       # @example
       #   break_time = LocalTime::NOON
       #

--- a/lib/openhab/core_ext/java/local_time.rb
+++ b/lib/openhab/core_ext/java/local_time.rb
@@ -36,15 +36,23 @@ module OpenHAB
         include Between
         # @!parse include Time
 
-        # @!visibility private
         class << self
+          # @!attribute [r] now
+          #   @return [LocalTime]
+
+          # @!visibility private
+          alias_method :raw_parse, :parse
+
           #
-          # Parses strings in the form "h[:mm[:ss]] [am/pm]"
+          # Parses strings in the form "h[:mm[:ss]] [am/pm]" when no formatter is given.
           #
           # @param [String] string
+          # @param [java.time.format.DateTimeFormatter] formatter The formatter to use
           # @return [LocalTime]
           #
-          def parse(string)
+          def parse(string, formatter = nil)
+            return raw_parse(string, formatter) if formatter
+
             format = /(am|pm)$/i.match?(string) ? "h[:mm[:ss][.S]][ ]a" : "H[:mm[:ss][.S]]"
             java_send(:parse, [java.lang.CharSequence, java.time.format.DateTimeFormatter],
                       string, java.time.format.DateTimeFormatterBuilder.new

--- a/lib/openhab/core_ext/java/month.rb
+++ b/lib/openhab/core_ext/java/month.rb
@@ -7,7 +7,7 @@ module OpenHAB
     module Java
       Month = java.time.Month
 
-      # Extensions to Month
+      # Extensions to {java.time.Month}
       class Month
         include Between
         # @!parse include Time

--- a/lib/openhab/core_ext/java/month_day.rb
+++ b/lib/openhab/core_ext/java/month_day.rb
@@ -7,7 +7,7 @@ module OpenHAB
     module Java
       java_import java.time.MonthDay
 
-      # Extensions to MonthDay
+      # Extensions to {java.time.MonthDay}
       class MonthDay
         include Between
         include Ephemeris

--- a/lib/openhab/core_ext/java/period.rb
+++ b/lib/openhab/core_ext/java/period.rb
@@ -5,7 +5,7 @@ module OpenHAB
     module Java
       java_import java.time.Period
 
-      # Extensions to Period
+      # Extensions to {java.time.Period}
       class Period
         # @!parse include TemporalAmount
 

--- a/lib/openhab/core_ext/java/temporal_amount.rb
+++ b/lib/openhab/core_ext/java/temporal_amount.rb
@@ -5,7 +5,7 @@ module OpenHAB
     module Java
       java_import java.time.temporal.TemporalAmount
 
-      # Extensions to TemporalAmount
+      # Extensions to {java.time.temporal.TemporalAmount}
       module TemporalAmount
         # Subtract `self` to {ZonedDateTime.now}
         # @return [ZonedDateTime]

--- a/lib/openhab/core_ext/java/zoned_date_time.rb
+++ b/lib/openhab/core_ext/java/zoned_date_time.rb
@@ -12,17 +12,21 @@ module OpenHAB
         include Time
         include Between
 
-        # @!scope class
+        class << self # rubocop:disable Lint/EmptyClass
+          # @!scope class
 
-        # @!attribute [r] now
-        #   @return [ZonedDateTime]
+          # @!attribute [r] now
+          #   @return [ZonedDateTime]
 
-        # @!method parse(text, formatter = nil)
-        #   Parses a string into a ZonedDateTime object.
-        #
-        #   @param [String] text The text to parse.
-        #   @param [java.time.format.DateTimeFormatter] formatter The formatter to use.
-        #   @return [ZonedDateTime]
+          # @!method parse(text, formatter = nil)
+          #   Parses a string into a ZonedDateTime object.
+          #
+          #   @param [String] text The text to parse.
+          #   @param [java.time.format.DateTimeFormatter] formatter The formatter to use.
+          #   @return [ZonedDateTime]
+        end
+
+        # @!scope instance
 
         # @return [LocalTime]
         def to_local_time(_context = nil)

--- a/lib/openhab/core_ext/java/zoned_date_time.rb
+++ b/lib/openhab/core_ext/java/zoned_date_time.rb
@@ -7,7 +7,7 @@ module OpenHAB
     module Java
       ZonedDateTime = java.time.ZonedDateTime
 
-      # Extensions to ZonedDateTime
+      # Extensions to {java.time.ZonedDateTime}
       class ZonedDateTime
         include Time
         include Between

--- a/lib/openhab/core_ext/java/zoned_date_time.rb
+++ b/lib/openhab/core_ext/java/zoned_date_time.rb
@@ -12,10 +12,17 @@ module OpenHAB
         include Time
         include Between
 
-        class << self # rubocop:disable Lint/EmptyClass
-          # @!attribute [r] now
-          #   @return [ZonedDateTime]
-        end
+        # @!scope class
+
+        # @!attribute [r] now
+        #   @return [ZonedDateTime]
+
+        # @!method parse(text, formatter = nil)
+        #   Parses a string into a ZonedDateTime object.
+        #
+        #   @param [String] text The text to parse.
+        #   @param [java.time.format.DateTimeFormatter] formatter The formatter to use.
+        #   @return [ZonedDateTime]
 
         # @return [LocalTime]
         def to_local_time(_context = nil)

--- a/spec/openhab/core_ext/java/local_time_spec.rb
+++ b/spec/openhab/core_ext/java/local_time_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe java.time.LocalTime do
     specify { expect { described_class.parse("17:00am") }.to raise_error ArgumentError }
     specify { expect(described_class.parse("7:30:20.12").to_s).to eql "07:30:20.120" }
     specify { expect(described_class.parse("7:30:20.12345").to_s).to eql "07:30:20.123450" }
+
+    it "can accept a formatter" do
+      formatter = java.time.format.DateTimeFormatter::ISO_OFFSET_TIME
+      expect(described_class.parse("10:15:30+00:00", formatter).to_s).to eql "10:15:30"
+    end
   end
 
   describe "#+" do


### PR DESCRIPTION
allow LocalTime.parse to accept a formatter

fix some yard errors on class methods - this could be a YARD bug. When a `class << self` doesn't contain any actual methods, and only contains yard meta tags like `@!attribute` or `@!method` it won't treat them as class attributes/methods. So an explicit `@!scope class` is needed in those cases.
