### PR TITLE
fix/improve DateTimeItem#format_type

### DIFF
--- a/lib/openhab/core/items/date_time_item.rb
+++ b/lib/openhab/core/items/date_time_item.rb
@@ -45,9 +45,9 @@ module OpenHAB
         # Time types need formatted as ISO8601
         # @!visibility private
         def format_type(command)
-          return Types::DateTimeType.new(command) if command.is_a?(java.time.ZonedDateTime)
+          return command if command.is_a?(Types::DateTimeType)
+          return Types::DateTimeType.new(command.to_zoned_date_time) if command.respond_to?(:to_zoned_date_time)
 
-          command = command.iso8601 if command.respond_to?(:iso8601)
           super
         end
       end


### PR DESCRIPTION
Use DateTimeType for Ruby times, instead of StringType. This will make .ensure (and other things) work properly because the resulting type will be properly comparable to the current item's state