### PR TITLE
fix `bundle console`

### DIFF
--- a/lib/openhab/rspec.rb
+++ b/lib/openhab/rspec.rb
@@ -16,6 +16,8 @@ require_relative "rspec/helpers"
 require_relative "rspec/karaf"
 require_relative "rspec/hooks"
 
+return unless defined?(RSpec)
+
 RSpec.configure do |c|
   c.add_setting :openhab_automation_search_paths, default: [
     "#{org.openhab.core.OpenHAB.config_folder}/automation/ruby",


### PR DESCRIPTION
It uses the RSpec helpers, but doesn't actually require RSpec

cc @ktgeek