### PR TITLE
add evolution_rate for a time range

### DIFF
--- a/spec/openhab/core/items/persistence_spec.rb
+++ b/spec/openhab/core/items/persistence_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe OpenHAB::Core::Items::Persistence do
         variance_since
       ].each do |method|
         item.__send__(method, 1.minute.ago)
+        item.__send__(method, 1.minute.ago, :influxdb)
       end
 
       %i[
@@ -26,6 +27,7 @@ RSpec.describe OpenHAB::Core::Items::Persistence do
         changed_between?
         delta_between
         deviation_between
+        evolution_rate
         maximum_between
         minimum_between
         sum_between
@@ -33,6 +35,7 @@ RSpec.describe OpenHAB::Core::Items::Persistence do
         variance_between
       ].each do |method|
         item.__send__(method, 2.minutes.ago, 1.minute.ago)
+        item.__send__(method, 2.minutes.ago, 1.minute.ago, :influxdb)
       end
     end.not_to raise_error
   end


### PR DESCRIPTION
evolution_rate doesn't have the "since/between" naming but it does support the same two versions, one with just "[since timestamp](https://www.openhab.org/javadoc/latest/org/openhab/core/persistence/extensions/persistenceextensions#evolutionRate(org.openhab.core.items.Item,java.time.ZonedDateTime))" and another for "[between start and finish](https://www.openhab.org/javadoc/latest/org/openhab/core/persistence/extensions/persistenceextensions#evolutionRate(org.openhab.core.items.Item,java.time.ZonedDateTime,java.time.ZonedDateTime,java.lang.String))".

