### PR TITLE
clean up item metadata and links when removing them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["3.3.0", "3.4.0", "4.0.0-SNAPSHOT"]
+        ["3.3.0", "3.4.0"]
       java_matrix: |
         ["11", "17"]
       snapshot_date: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["3.4.0"]
+        ["3.4.1"]
       java_matrix: |
         ["11", "17"]
       snapshot_date: |
@@ -167,7 +167,7 @@ jobs:
         openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
         java_version:  ${{ fromJson(needs.openhab-matrix.outputs.java_matrix) }}
         exclude:
-          - openhab_version: 3.4.0
+          - openhab_version: 3.4.1
             java_version: 17
           - openhab_version: 4.0.0-SNAPSHOT
             java_version: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["3.3.0", "3.4.0"]
+        ["3.4.0"]
       java_matrix: |
         ["11", "17"]
       snapshot_date: |
@@ -121,10 +121,6 @@ jobs:
         java_version:  ${{ fromJson(needs.openhab-matrix.outputs.java_matrix) }}
         jruby_version: ["jruby-9.3.9.0", "jruby-9.4.0.0"]
         exclude:
-          - openhab_version: 3.3.0
-            jruby_version: jruby-9.4.0.0
-          - openhab_version: 3.3.0
-            java_version: 17
           - openhab_version: 3.4.0
             java_version: 17
           - openhab_version: 4.0.0-SNAPSHOT
@@ -171,8 +167,6 @@ jobs:
         openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
         java_version:  ${{ fromJson(needs.openhab-matrix.outputs.java_matrix) }}
         exclude:
-          - openhab_version: 3.3.0
-            java_version: 17
           - openhab_version: 3.4.0
             java_version: 17
           - openhab_version: 4.0.0-SNAPSHOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ here is a non-exhaustive list of significant departures from the original gem:
 
 ### Breaking Changes
 
-* Dropping support for openHAB < 3.3.
+* Dropping support for openHAB < 3.4.
 * The main require is now `require "openhab/dsl"` instead of just
   `require "openhab"`. The reason being to avoid conflicts if a gem gets
   written to access openHAB via REST API. It's probably preferred that you

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    openhab-jrubyscripting (5.0.0.rc11)
+    openhab-jrubyscripting (5.0.0.rc12)
       bundler (~> 2.2)
       marcel (~> 1.0)
       method_source (~> 1.0)

--- a/lib/openhab/core.rb
+++ b/lib/openhab/core.rb
@@ -3,12 +3,12 @@
 module OpenHAB
   # Contains classes and modules that wrap actual openHAB objects
   module Core
-    # The openHAB Version. >= 3.3.0 is required.
+    # The openHAB Version. >= 3.4.0 is required.
     # @return [String]
     VERSION = org.openhab.core.OpenHAB.version.freeze
 
-    unless Gem::Version.new(VERSION) >= Gem::Version.new("3.3.0")
-      raise "`openhab-jrubyscripting` requires openHAB >= 3.3.0"
+    unless Gem::Version.new(VERSION) >= Gem::Version.new("3.4.0")
+      raise "`openhab-jrubyscripting` requires openHAB >= 3.4.0"
     end
 
     # @return [Integer] Number of seconds to wait between checks for automation manager

--- a/lib/openhab/core/items/item.rb
+++ b/lib/openhab/core/items/item.rb
@@ -185,7 +185,7 @@ module OpenHAB
         #
         # @return [Array<Thing>] An array of things or an empty array
         def things
-          registry = OSGi.service("org.openhab.core.thing.link.ItemChannelLinkRegistry")
+          registry = Things::Links::Provider.registry
           channels = registry.get_bound_channels(name).to_a
           channels.map(&:thing_uid).uniq.map { |tuid| EntityLookup.lookup_thing(tuid) }.compact
         end

--- a/lib/openhab/core/items/metadata/provider.rb
+++ b/lib/openhab/core/items/metadata/provider.rb
@@ -32,8 +32,8 @@ module OpenHAB
           # @return [void]
           #
           def remove_item_metadata(item_name)
-            @elements.delete_if do |k, v|
-              next unless k.item_name == item_name
+            @elements.delete_if do |_k, v|
+              next unless v.uid.item_name == item_name
 
               notify_listeners_about_removed_element(v)
               true

--- a/lib/openhab/core/registry.rb
+++ b/lib/openhab/core/registry.rb
@@ -4,7 +4,7 @@ module OpenHAB
   module Core
     Registry = org.openhab.core.common.registry.AbstractRegistry
 
-    Registry.field_reader :elementToProvider, :elementReadLock, :identifierToElement
+    Registry.field_reader :elementToProvider, :elementReadLock, :identifierToElement, :providerToElements
 
     # @abstract
     #
@@ -28,6 +28,12 @@ module OpenHAB
         elementToProvider[element]
       ensure
         elementReadLock.unlock
+      end
+
+      # @!attribute [r] providers
+      # @return [Enumerable<org.openhab.core.common.registry.Provider>]
+      def providers
+        providerToElements.keys
       end
     end
   end

--- a/lib/openhab/core/things/links/provider.rb
+++ b/lib/openhab/core/things/links/provider.rb
@@ -33,6 +33,44 @@ module OpenHAB
               current.add(link)
             end
           end
+
+          #
+          # Removes all links to a given item.
+          #
+          # @param [String] item_name
+          # @return [Integer] how many links were removed
+          #
+          def remove_links_for_item(item_name)
+            count = 0
+            @elements.delete_if do |_k, v|
+              next unless v.item_name == item_name
+
+              count += 1
+              notify_listeners_about_removed_element(v)
+              true
+            end
+            count
+          end
+          alias_method :removeLinksForItem, :remove_links_for_item
+
+          #
+          # Removes all links to a given thing.
+          #
+          # @param [ThingUID] thing_uid
+          # @return [Integer] how many links were removed
+          #
+          def remove_links_for_thing(thing_uid)
+            count = 0
+            @elements.delete_if do |_k, v|
+              next unless v.linked_uid.thing_uid == thing_uid
+
+              count += 1
+              notify_listeners_about_removed_element(v)
+              true
+            end
+            count
+          end
+          alias_method :removeLinksForThing, :remove_links_for_thing
         end
       end
     end

--- a/lib/openhab/core/things/registry.rb
+++ b/lib/openhab/core/things/registry.rb
@@ -61,6 +61,10 @@ module OpenHAB
             raise "Cannot remove thing #{thing_uid} from non-managed provider #{provider.inspect}"
           end
 
+          Links::Provider.registry.providers.grep(ManagedProvider).each do |managed_provider|
+            managed_provider.remove_links_for_thing(thing_uid)
+          end
+
           provider.remove(thing_uid)
         end
       end

--- a/lib/openhab/core/timer.rb
+++ b/lib/openhab/core/timer.rb
@@ -28,7 +28,7 @@ module OpenHAB
       #   @return [true,false]
 
       def_delegator :@timer, :has_terminated, :terminated?
-      def_delegators :@timer, :active?, :cancelled?, :running?
+      def_delegators :@timer, :active?, :cancelled?, :running?, :execution_time
 
       # @return [Object, nil]
       attr_accessor :id
@@ -49,19 +49,7 @@ module OpenHAB
         @id = id
         @thread_locals = thread_locals
         @block = block
-        @timer = if defined?(ScriptExecution)
-                   ScriptExecution.create_timer(1.minute.from_now) { execute }
-                 else # DEPRECATED: openHAB 3.4.0
-                   org.openhab.core.model.script.actions.ScriptExecution.create_timer(
-                     # create it far enough in the future so it won't execute until we finish setting it up
-                     1.minute.from_now,
-                     # when running in rspec, it may have troubles finding this class
-                     # for auto-conversion of block to interface, so use .impl
-                     org.eclipse.xtext.xbase.lib.Procedures::Procedure0.impl { execute }
-                   )
-                 end
-        # DEPRECATED: openHAB 3.4.0.M6
-        @timer.class.field_reader :future unless @timer.respond_to?(:future)
+        @timer = ScriptExecution.create_timer(1.minute.from_now) { execute }
         reschedule(@time)
       end
 
@@ -79,11 +67,7 @@ module OpenHAB
       alias_method :to_s, :inspect
 
       # @!attribute [r] execution_time
-      # @return [ZonedDateTime, nil] the scheduled execution time, or `nil` if the timer was cancelled
-      def execution_time
-        # DEPRECATED: openHAB 3.4.0.M6 (just remove the entire method)
-        @timer.future.scheduled_time
-      end
+      #   @return [ZonedDateTime, nil] the scheduled execution time, or `nil` if the timer was cancelled
 
       #
       # Reschedule timer

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -152,8 +152,6 @@ module OpenHAB
     #
     # @see Core::ValueCache ValueCache
     #
-    # @since openHAB 3.4.0
-    #
     def shared_cache
       $sharedCache
     end

--- a/lib/openhab/dsl/version.rb
+++ b/lib/openhab/dsl/version.rb
@@ -4,6 +4,6 @@ module OpenHAB
   module DSL
     # Version of openHAB helper libraries
     # @return [String]
-    VERSION = "5.0.0.rc11"
+    VERSION = "5.0.0.rc12"
   end
 end

--- a/spec/openhab/core/value_cache_spec.rb
+++ b/spec/openhab/core/value_cache_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "OpenHAB::Core::ValueCache" do
-  before do
-    skip "Requires openHAB 3.4.0" if shared_cache.nil?
-  end
-
   describe "#key?" do
     it "returns false for missing keys" do
       expect(shared_cache).not_to have_key(:key)

--- a/spec/openhab/dsl/items/builder_spec.rb
+++ b/spec/openhab/dsl/items/builder_spec.rb
@@ -17,9 +17,12 @@ RSpec.describe OpenHAB::DSL::Items::Builder do
   end
 
   it "can remove an item" do
-    items.build { switch_item "MySwitchItem" }
+    items.build { switch_item "MySwitchItem", autoupdate: false, channel: "binding:type:thing:channel" }
     items.remove(MySwitchItem)
     expect(items["MySwitchItem"]).to be_nil
+    # make sure metadata and channel links also got cleaned up
+    expect(OpenHAB::Core::Items::Metadata::Provider.instance.all).to be_empty
+    expect(OpenHAB::Core::Things::Links::Provider.instance.all).to be_empty
   end
 
   it "can create items in a group" do


### PR DESCRIPTION
they would be cleaned up anyway if it was from the script's provider when the script is unloaded, but sometimes a script will remove and re-add the same item without being reloaded (like if it's automatically creating items when things are added/removed)