### PR TITLE
drop implicit comparisons between PercentType and OnOffType etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,14 @@ here is a non-exhaustive list of significant departures from the original gem:
   While convenient at times, it introduces many ambiguities on if the intention
   is to interact with the item or its state, and contortionist code attempting
   to support both use cases.
-* Semi-related to the above, the `#truthy?` method has been removed from any
-  items the previously implemented it. Instead, be more explicit on what you
-  mean - for example `Item.on?`. If you would like to use a similar structure
-  with {StringItem}s, just [include the ActiveSupport gem](USAGE.md#gems)
-  in your rules to get `#blank?` and `#present?` methods, and then you can
-  use `Item.state.present?`.
+* {OpenHAB::Core::Types::Type Enum types} no longer have implicit conversions for comparisons.
+  This means you can no longer do `DimmerItem.state == ON`.
+  Predicate methods retain the implicit conversion semantics, so you _can_ do `DimmerItem.on?`.
+  `ensure.on`, etc. also still retain their internal implicit comparisons, so you can also still do `DimmerItem.ensure.on` and it will _not_ send {ON} if the item is anything but `0`.
+  {OpenHAB::Core::Events::ItemStateEvent} and {OpenHAB::Core::Events::ItemStateChangedEvent} both now have a full set of predicate methods to ease use from within rule execution blocks.
+* Semi-related to the above two points, the `#truthy?` method has been removed from any items the previously implemented it.
+  Instead, be more explicit on what you mean - for example `Item.on?`.
+  If you would like to use a similar structure with {StringItem StringItems}, just [include the ActiveSupport gem](USAGE.md#gems) in your rules to get `#blank?` and `#present?` methods, and then you can use `Item.state.present?`.
 * Semi-related to the above, the
   {OpenHAB::DSL::Rules::BuilderDSL#only_if only_if} and
   {OpenHAB::DSL::Rules::BuilderDSL#not_if not_if} guards now _only_ take blocks.
@@ -185,6 +187,7 @@ here is a non-exhaustive list of significant departures from the original gem:
 * A set of debounce/throttle guards for file-based rules: {OpenHAB::DSL::Rules::BuilderDSL#debounce_for debounce_for}, {OpenHAB::DSL::Rules::BuilderDSL#throttle_for throttle_for}, and {OpenHAB::DSL::Rules::BuilderDSL#only_every only_every} 
 * And for UI rules: {OpenHAB::DSL.debounce_for debounce_for}, {OpenHAB::DSL.throttle_for throttle_for}, {OpenHAB::DSL.only_every only_every}
 * Explicitly document modifying item tags, labels and categories (where possible), and notify openHAB of the change
+* {OpenHAB::Core::Events::ItemStateEvent} and {OpenHAB::Core::Events::ItemStateChangedEvent} now have full sets of predicate methods.
 
 ### Bug Fixes
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -536,26 +536,23 @@ See {OpenHAB::DSL.unit unit block}
 Some openHAB item types can accept different command types.
 For example, a {DimmerItem} can accept a command with an {OnOffType}, {IncreaseDecreaseType} or a {PercentType}.
 However, ultimately an item only stores its state in its native type, e.g. a {DimmerItem DimmerItems}'s native type is {PercentType}.
-
-Comparisons between two compatible types will return true when applicable, for example:
-
-* `0` ({PercentType}) equals {OFF} and the `off?` predicate will return true
-* A positive {PercentType} equals {ON} and the `on?` predicate will return true
+In some contexts, you don't care about the precise value of a particular state, and just want to know if it fits the general definition of {ON}, etc.
+You can either explicitly convert to the general type, _or_ all of the state predicate methods available on {Item}, {OpenHAB::Core::Events::ItemStateEvent ItemStateEvent}, {OpenHAB::Core::Events::ItemStateChangedEvent ItemStateChangedEvent}, {OpenHAB::Core::Events::ItemCommandEvent ItemCommandEvent}, as well as specific types such as {PercentType} and {HSBType}, will do the conversion internally.
 
 ```ruby
 DimmerItem1.update(10)
 sleep 1
 DimmerItem1.state == 10 # => true
-DimmerItem1.state == ON # => true
+DimmerItem1.state == ON # => false
+DimmerItem1.state.as(OnOffType) == ON # => true
+DimmerItem1.state.on? # => true
 DimmerItem1.on? # => true
 DimmerItem1.off? # => false
-```
 
-```ruby
 rule 'command' do
   received_command DimmerItem1
   run do |event|
-    if event.command.on?
+    if event.on?
       # This will be executed even when the command is a positive PercentType
       # instead of an actual ON command
       logger.info("DimmerItem1 is being turned on")
@@ -564,63 +561,6 @@ rule 'command' do
 end
 
 DimmerItem1 << 100 # => This will trigger the logger.info above
-```
-
-##### Bypassing Loose Type-Comparisons <!-- omit from toc -->
-
-If at any point you want to bypass loose type conversions, use `eql?`.
-
-```ruby
-DimmerItem1.update(10)
-sleep 1
-logger.error DimmerItem1.eql?(10) # => false. It compares the _item_ object not its state
-logger.error DimmerItem1.eql?(items['DimmerItem1']) # => true. It compares the _item_ object
-logger.error DimmerItem1.state.eql?(ON) # => false
-logger.error DimmerItem1.state.eql?(10) # => false
-logger.error DimmerItem1.state.eql?(PercentType.new(10)) # => true
-```
-
-##### Strict Type-Comparisons <!-- omit from toc -->
-
-Sometimes it is critical to know the exact command being sent.
-For example, a rule may need to distinguish between {ON} vs. a {PercentType} command.
-In this instance, Ruby's case equality operator `===` can be used.
-It will only evaluate to true if the two operands have the same type.
-The strict type comparison applies to Ruby's `case` statement because it is implemented using the case equality operator `===`.
-
-```ruby
-rule 'command' do
-  received_command DimmerItem1
-  run do |event|
-    case event.command
-    when ON then logger.info("DimmerItem1 received an ON command")
-    when OFF then logger.info("DimmerItem1 received an OFF command")
-    when 0 then logger.info("DimmerItem1 received 0 percent")
-    when 1..99 then logger.info("DimmerItem1 received between 1 and 99 percent")
-    when 100 then logger.info("DimmerItem1 received 100 percent")
-    when INCREASE then logger.info("Increase")
-    when DECREASE then logger.info("Decrease")
-    when REFRESH then logger.info("Refresh")
-    end
-  end
-end
-
-```
-
-Regular expressions can still be used on a {StringType} command.
-
-```ruby
-rule 'command' do
-  received_command StringItem1
-  run do |event|
-    case event.command
-    when /abc/ then logger.info('Command contains "abc"')
-    else logger.info('Received something else')
-    end
-  end
-end
-
-StringItem1 << '123 abc 456' # This will log 'Command contains "abc"'
 ```
 
 #### Metadata

--- a/lib/openhab/core/events/item_command_event.rb
+++ b/lib/openhab/core/events/item_command_event.rb
@@ -7,71 +7,71 @@ module OpenHAB
     module Events
       java_import org.openhab.core.items.events.ItemCommandEvent
 
-      # Adds methods to core openHAB ItemCommandEvent to make it more natural in Ruby
+      # {AbstractEvent} sent when an item receives a command.
       class ItemCommandEvent < ItemEvent
         # @!attribute [r] command
         # @return [Command] The command sent to the item.
         alias_method :command, :item_command
 
         # @!method refresh?
-        #   Check if `self == REFRESH`
-        #   @return [true,false]
+        #   Check if {#command} is {REFRESH}
+        #   @return [true, false]
 
         # @!method on?
-        #   Check if `self == ON`
-        #   @return [true,false]
+        #   Check if {#command} is (implicitly convertible to) {ON}
+        #   @return [true, false]
 
         # @!method off?
-        #   Check if `self == OFF`
-        #   @return [true,false]
+        #   Check if {#command} is (implicitly convertible to) {OFF}
+        #   @return [true, false]
 
         # @!method up?
-        #   Check if `self == UP`
-        #   @return [true,false]
+        #   Check if {#command} is (implicitly convertible to) {UP}
+        #   @return [true, false]
 
         # @!method down?
-        #   Check if `self == DOWN`
-        #   @return [true,false]
+        #   Check if {#command} is (implicitly convertible to) {DOWN}
+        #   @return [true, false]
 
         # @!method stop?
-        #   Check if `self == STOP`
-        #   @return [true,false]
+        #   Check if {#command} is {STOP}
+        #   @return [true, false]
 
         # @!method move?
-        #   Check if `self == MOVE`
-        #   @return [true,false]
+        #   Check if {#command} is {MOVE}
+        #   @return [true, false]
 
         # @!method increase?
-        #   Check if `self == INCREASE`
-        #   @return [true,false]
+        #   Check if {#command} is {INCREASE}
+        #   @return [true, false]
 
         # @!method decrease?
-        #   Check if `self == DECREASE`
-        #   @return [true,false]
+        #   Check if {#command} is {DECREASE}
+        #   @return [true, false]
 
         # @!method play?
-        #   Check if `self == PLAY`
-        #   @return [true,false]
+        #   Check if {#command} is {PLAY}
+        #   @return [true, false]
 
         # @!method pause?
-        #   Check if `self == PAUSE`
-        #   @return [true,false]
+        #   Check if {#command} is {PAUSE}
+        #   @return [true, false]
 
         # @!method rewind?
-        #   Check if `self == REWIND`
-        #   @return [true,false]
+        #   Check if {#command} is {REWIND}
+        #   @return [true, false]
 
         # @!method fast_forward?
-        #   Check if `self == FASTFORWARD`
-        #   @return [true,false]
+        #   Check if {#command} is {FASTFORWARD}
+        #   @return [true, false]
 
         # @!method next?
-        #   Check if `self == NEXT`
-        #   @return [true,false]
+        #   Check if {#command} is {NEXT}
+        #   @return [true, false]
 
         # @!method previous?
-        #   Check if `self == PREVIOUS`
-        #   @return [true,false]
+        #   Check if {#command} is {PREVIOUS}
+        #   @return [true, false]
       end
     end
   end

--- a/lib/openhab/core/events/item_state_changed_event.rb
+++ b/lib/openhab/core/events/item_state_changed_event.rb
@@ -8,32 +8,55 @@ module OpenHAB
       java_import org.openhab.core.items.events.ItemStateChangedEvent
 
       #
-      # Adds methods to core openHAB ItemStateChangedEvent to make it more natural in Ruby
+      # {AbstractEvent} sent when an item's state has changed.
       #
       class ItemStateChangedEvent < ItemEvent
         include ItemState
 
-        #
-        # Check if state was == {UNDEF}
-        #
-        # @return [true,false] True if the state is {UNDEF}, false otherwise
-        #
-        def was_undef?
-          old_item_state == UNDEF
-        end
+        # @!method was_undef?
+        #   Check if {#was} is {UNDEF}
+        #   @return [true, false]
 
-        #
-        # Check if state was == {NULL}
-        #
-        # @return [true,false] True if the state is {NULL}, false otherwise
-        def was_null?
-          old_item_state == NULL
-        end
+        # @!method was_null?
+        #   Check if {#was} is {NULL}
+        #   @return [true, false]
+
+        # @!method was_on?
+        #   Check if {#was} is (implicitly convertible to) {ON}
+        #   @return [true, false]
+
+        # @!method was_off?
+        #   Check if {#was} is (implicitly convertible to) {OFF}
+        #   @return [true, false]
+
+        # @!method was_up?
+        #   Check if {#was} is (implicitly convertible to) {UP}
+        #   @return [true, false]
+
+        # @!method was_down?
+        #   Check if {#was} is (implicitly convertible to) {DOWN}
+        #   @return [true, false]
+
+        # @!method was_open?
+        #   Check if {#was} is (implicitly convertible to) {OPEN}
+        #   @return [true, false]
+
+        # @!method was_closed?
+        #   Check if {#was} is (implicitly convertible to) {CLOSED}
+        #   @return [true, false]
+
+        # @!method was_playing?
+        #   Check if {#was} is {PLAY}
+        #   @return [true, false]
+
+        # @!method was_paused?
+        #   Check if {#was} is {PAUSE}
+        #   @return [true, false]
 
         #
         # Check if state was defined (not {UNDEF} or {NULL})
         #
-        # @return [true,false] True if state is not {UNDEF} or {NULL}
+        # @return [true,false]
         #
         def was?
           !old_item_state.is_a?(UnDefType)
@@ -41,7 +64,7 @@ module OpenHAB
 
         #
         # @!attribute [r] was
-        # @return [State, nil] The state of the item if it was not {UNDEF} or {NULL}, `nil` otherwise.
+        # @return [State, nil] the prior state of the item if it was not {UNDEF} or {NULL}, `nil` otherwise.
         #
         def was
           old_item_state if was?

--- a/lib/openhab/core/events/item_state_event.rb
+++ b/lib/openhab/core/events/item_state_event.rb
@@ -5,29 +5,57 @@ module OpenHAB
     module Events
       java_import org.openhab.core.items.events.ItemStateEvent
 
+      #
       # Helpers common to {ItemStateEvent} and {ItemStateChangedEvent}.
+      #
+      # Methods that refer to implicit conversion mean that for example
+      # a PercentType of 100% will be `true` for {#on?}, etc.
+      #
       module ItemState
-        #
-        # Check if the state == {UNDEF}
-        #
-        # @return [true,false] True if the state is {UNDEF}, false otherwise
-        #
-        def undef?
-          item_state == UNDEF
-        end
+        # @!method undef?
+        #   Check if {#state} is {UNDEF}
+        #   @return [true, false]
+
+        # @!method null?
+        #   Check if {#state} is {NULL}
+        #   @return [true, false]
+
+        # @!method on?
+        #   Check if {#state} is (implicitly convertible to) {ON}
+        #   @return [true, false]
+
+        # @!method off?
+        #   Check if {#state} is (implicitly convertible to) {OFF}
+        #   @return [true, false]
+
+        # @!method up?
+        #   Check if {#state} is (implicitly convertible to) {UP}
+        #   @return [true, false]
+
+        # @!method down?
+        #   Check if {#state} is (implicitly convertible to) {DOWN}
+        #   @return [true, false]
+
+        # @!method open?
+        #   Check if {#state} is (implicitly convertible to) {OPEN}
+        #   @return [true, false]
+
+        # @!method closed?
+        #   Check if {#state} is (implicitly convertible to) {CLOSED}
+        #   @return [true, false]
+
+        # @!method playing?
+        #   Check if {#state} is {PLAY}
+        #   @return [true, false]
+
+        # @!method paused?
+        #   Check if {#state} is {PAUSE}
+        #   @return [true, false]
 
         #
-        # Check if the state == {NULL}
+        # Check if {#state} is defined (not {UNDEF} or {NULL})
         #
-        # @return [true,false] True if the state is {NULL}, false otherwise
-        def null?
-          item_state == NULL
-        end
-
-        #
-        # Check if the state is defined (not {UNDEF} or {NULL})
-        #
-        # @return [true,false] True if state is not {UNDEF} or {NULL}
+        # @return [true, false]
         #
         def state?
           !item_state.is_a?(UnDefType)
@@ -35,7 +63,7 @@ module OpenHAB
 
         #
         # @!attribute [r] state
-        # @return [State, nil] The state of the item if it is not {UNDEF} or {NULL}, `nil` otherwise.
+        # @return [State, nil] the state of the item if it is not {UNDEF} or {NULL}, `nil` otherwise.
         #
         def state
           item_state if state?

--- a/lib/openhab/core/items.rb
+++ b/lib/openhab/core/items.rb
@@ -46,9 +46,9 @@ module OpenHAB
 
             logger.trace("Defining #{klass}##{state_predicate} for #{state}")
             klass.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-              def #{state_predicate}   # def on?
-                raw_state == #{state}  #   raw_state == ON
-              end                      # end
+              def #{state_predicate}                                                  # def on?
+                raw_state.as(#{state.class.java_class.simple_name}).equal?(#{state})  #   raw_state.as(OnOffType) == ON
+              end                                                                     # end
             RUBY
           end
         end
@@ -83,9 +83,9 @@ module OpenHAB
 
             logger.trace("Defining ItemCommandEvent##{command}? for #{value}")
             Events::ItemCommandEvent.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-              def #{command}?        # def refresh?
-                command == #{value}  #   command == REFRESH
-              end                    # end
+              def #{command}?                                                       # def refresh?
+                command.as(#{value.class.java_class.simple_name}).equal?(#{value})  #   command.as(RefreshType).equal?(REFRESH)
+              end                                                                   # end
             RUBY
           end
         end

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -153,7 +153,7 @@ module OpenHAB
           return state if state.is_a?(Types::State)
 
           state = state.to_s
-          org.openhab.core.types.TypeParser.parse_state(getAcceptedDataTypes, state) || state
+          org.openhab.core.types.TypeParser.parse_state(getAcceptedDataTypes, state) || StringType.new(state)
         end
 
         # formats a {Types::Type} to send to the event bus

--- a/lib/openhab/core/types/decimal_type.rb
+++ b/lib/openhab/core/types/decimal_type.rb
@@ -110,20 +110,15 @@ module OpenHAB
         #
         # Coerce object to a {DecimalType DecimalType}
         #
-        # @param [Numeric, Type] other object to coerce to a {DecimalType DecimalType}
-        #
-        #   If `other` is a {Type}, `self` will instead be coerced
-        #   to that type to accomodate comparison with things such as {OnOffType}.
+        # @param [Numeric] other object to coerce to a {DecimalType DecimalType}
         #
         # @return [Array<(DecimalType, DecimalType)>, nil]
         #
         def coerce(other)
           logger.trace("Coercing #{self} as a request from #{other.class}")
-          if other.is_a?(Type)
-            [other, as(other.class)]
-          elsif other.respond_to?(:to_d)
-            [self.class.new(other.to_d), self]
-          end
+          return unless other.respond_to?(:to_d)
+
+          [self.class.new(other.to_d), self]
         end
 
         #

--- a/lib/openhab/core/types/quantity_type.rb
+++ b/lib/openhab/core/types/quantity_type.rb
@@ -157,19 +157,14 @@ module OpenHAB
         #
         # Coerce object to a {QuantityType}
         #
-        # @param [Numeric, Type] other object to coerce to a {QuantityType}
-        #
-        #   if `other` is a {Type}, `self` will instead be coerced
-        #   to that type to accomodate comparison with things such as {OnOffType}
+        # @param [Numeric] other object to coerce to a {QuantityType}
         #
         # @return [Array<(QuantityType, QuantityType)>, nil]
         def coerce(other)
           logger.trace("Coercing #{self} as a request from #{other.class}")
-          if other.is_a?(Type)
-            [other, as(other.class)]
-          elsif other.respond_to?(:to_d)
-            [QuantityType.new(other.to_d.to_java, Units::ONE), self]
-          end
+          return unless other.respond_to?(:to_d)
+
+          [QuantityType.new(other.to_d.to_java, Units::ONE), self]
         end
 
         # arithmetic operators

--- a/lib/openhab/core/types/string_type.rb
+++ b/lib/openhab/core/types/string_type.rb
@@ -63,7 +63,7 @@ module OpenHAB
         #
         def coerce(other)
           logger.trace("Coercing #{self} as a request from #{other.class}")
-          return [String.new(other.to_str), self] if other.respond_to?(:to_str)
+          return [other.to_str, self] if other.respond_to?(:to_str)
         end
 
         # any method that exists on String gets forwarded to to_s

--- a/lib/openhab/core/types/type.rb
+++ b/lib/openhab/core/types/type.rb
@@ -26,21 +26,6 @@ module OpenHAB
         end
 
         #
-        # Type Coercion
-        #
-        # Coerce object to the same Type
-        #
-        # @param [Type] other object to coerce to the same
-        #   Type as this one
-        #
-        # @return [[Type, Type], nil]
-        #
-        def coerce(other)
-          logger.trace("Coercing #{self} (#{self.class}) as a request from #{other.class}")
-          return [other.as(self.class), self] if other.is_a?(Type) && other.respond_to?(:as)
-        end
-
-        #
         # Check equality without type conversion
         #
         # @return [true,false] if the same value is represented, without type
@@ -49,19 +34,6 @@ module OpenHAB
           return false unless other.instance_of?(self.class)
 
           equals(other)
-        end
-
-        #
-        # Case equality
-        #
-        # @return [true,false] if the values are of the same Type
-        #                   or item state of the same type
-        #
-        def ===(other)
-          logger.trace { "Type (#{self.class}) #{self} === #{other} (#{other.class})" }
-          return false unless instance_of?(other.class)
-
-          eql?(other)
         end
 
         #
@@ -94,6 +66,14 @@ module OpenHAB
           end
 
           super
+        end
+
+        # @!visibility private
+        #
+        # some openHAB Types don't implement as; do it for them
+        #
+        def as(klass)
+          self if klass == self.class
         end
       end
 

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -54,7 +54,7 @@ module OpenHAB
                 logger.trace do
                   "\#{name} ensure \#{state}, format_#{ensured_method}: \#{formatted_state}, current state: \#{raw_state}"
                 end
-                return if raw_state == formatted_state
+                return if raw_state.as(formatted_state.class) == formatted_state
 
                 super(formatted_state)
               end

--- a/spec/openhab/core/types/hsb_type_spec.rb
+++ b/spec/openhab/core/types/hsb_type_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OpenHAB::Core::Types::HSBType do
     specify { expect(HSBType::RED).to eq HSBType::RED }
     specify { expect(HSBType::RED != HSBType::RED).to be false }
     specify { expect(HSBType::RED).to eq 100 }
-    specify { expect(HSBType::RED).to eq ON }
+    specify { expect(HSBType::RED).not_to eq ON }
     specify { expect(HSBType::RED).not_to eq HSBType.new(1, 100, 100) }
     specify { expect(HSBType::RED).not_to eq HSBType.new(0, 99, 100) }
     specify { expect(HSBType::RED).not_to eq HSBType.new(0, 100, 99) }

--- a/spec/openhab/core/types/on_off_type_spec.rb
+++ b/spec/openhab/core/types/on_off_type_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe OpenHAB::Core::Types::OnOffType do
     let(:fifty) { PercentType.new(50) }
     let(:zero) { PercentType::ZERO }
 
-    specify { expect(fifty).to eq ON }
-    specify { expect(zero).to eq OFF }
+    specify { expect(fifty).not_to eq ON }
+    specify { expect(zero).not_to eq OFF }
     specify { expect(fifty).not_to eq OFF }
     specify { expect(zero).not_to eq ON }
-    specify { expect(ON).to eq fifty }
+    specify { expect(ON).not_to eq fifty }
     specify { expect(ON).not_to eq zero }
-    specify { expect(OFF).to eq zero }
+    specify { expect(OFF).not_to eq zero }
     specify { expect(OFF).not_to eq fifty }
 
     specify { expect(ON).not_to eq NULL }

--- a/spec/openhab/core/types/percent_type_spec.rb
+++ b/spec/openhab/core/types/percent_type_spec.rb
@@ -128,9 +128,9 @@ RSpec.describe OpenHAB::Core::Types::PercentType do
 
     # PercentType vs OnOffType
     specify { expect(ten).not_to eql ON }
-    specify { expect(ten).to eq ON }
+    specify { expect(ten).not_to eq ON }
     specify { expect(ten).not_to eq OFF }
-    specify { expect(ten != ON).to be false }
+    specify { expect(ten != ON).to be true }
     specify { expect(ten != OFF).to be true }
 
     # Numeric vs PercentType


### PR DESCRIPTION
it's rarely used directly anyway, and _not_ doing it eliminates an entire section of "gotcha" from the usage doc (as well as gotches while you're using the library!). the implicit comparisons are still used in state predicate methods and ensure comparisons