### PR TITLE
refactor script_uploaded priority

### DIFF
--- a/lib/openhab/core/items/provider.rb
+++ b/lib/openhab/core/items/provider.rb
@@ -34,6 +34,10 @@ module OpenHAB
           item.members.each { |member| remove(member.name, true) } if recursive && item.is_a?(GroupItem)
           item
         end
+
+        def initialize
+          super(unload_priority: 50)
+        end
       end
     end
   end

--- a/lib/openhab/core/provider.rb
+++ b/lib/openhab/core/provider.rb
@@ -219,11 +219,11 @@ module OpenHAB
 
       private
 
-      def initialize(script_unloaded_before: nil)
+      def initialize(unload_priority: nil)
         super()
         @elements = java.util.concurrent.ConcurrentHashMap.new
         self.class.registry.add_provider(self)
-        ScriptHandling.script_unloaded(before: script_unloaded_before) { unregister }
+        ScriptHandling.script_unloaded(priority: unload_priority) { unregister }
       end
     end
   end

--- a/lib/openhab/core/rules/provider.rb
+++ b/lib/openhab/core/rules/provider.rb
@@ -19,21 +19,6 @@ module OpenHAB
             $rules
           end
         end
-
-        def initialize
-          super(script_unloaded_before: lambda do |callbacks|
-            callbacks.index do |cb|
-              case cb.binding.receiver
-              when Items::Provider,
-                Things::Provider,
-                DSL::TimerManager
-                true
-              else
-                false
-              end
-            end
-          end)
-        end
       end
     end
   end

--- a/lib/openhab/core/script_handling.rb
+++ b/lib/openhab/core/script_handling.rb
@@ -33,8 +33,6 @@ module OpenHAB
       end
 
       #
-      # @!method script_unloaded(&block)
-      #
       # Add a block of code to be executed when the script is unloaded.
       #
       # This can occur when openHAB shuts down, or when the script is being reloaded.
@@ -42,6 +40,10 @@ module OpenHAB
       # Multiple hooks can be added by calling {#script_unloaded} multiple times.
       # They can be used to perform final cleanup.
       #
+      # @param [Integer, nil] priority The order at which the the given hook will be executed.
+      #   The higher the number, the lower the priority. Higher priority hooks will be executed
+      #   first, before the lower priority hooks. When nil, the default priority of zero will
+      #   be used.
       # @return [void]
       #
       # @example
@@ -49,10 +51,8 @@ module OpenHAB
       #     logger.info 'Hi, this script has been unloaded'
       #   end
       #
-      def script_unloaded(before: nil, &block)
-        # `before` is as yet undocumented, because I'm not set on its interface
-        index = before.call(ScriptHandlingCallbacks.script_unloaded_hooks) if before
-        ScriptHandlingCallbacks.script_unloaded_hooks.insert(index || -1, block)
+      def script_unloaded(priority: nil, &block)
+        ScriptHandlingCallbacks.script_unloaded_hooks[priority || 0] << block
       end
     end
 
@@ -82,7 +82,7 @@ module OpenHAB
         #
         # @!visibility private
         def script_unloaded_hooks
-          @script_unloaded_hooks ||= []
+          @script_unloaded_hooks ||= Hash.new { |hash, key| hash[key] = [] }
         end
       end
       self.script_loaded = false
@@ -92,7 +92,12 @@ module OpenHAB
       #
       def scriptUnloaded # rubocop:disable Naming/MethodName method name dictated by openHAB
         logger.trace("Script unloaded")
-        ScriptHandlingCallbacks.script_unloaded_hooks.each do |hook|
+        ScriptHandlingCallbacks.script_unloaded_hooks
+                               .to_a
+                               .sort_by(&:first)
+                               .map(&:last)
+                               .flatten
+                               .each do |hook|
           hook.call
         rescue => e
           logger.error("Failed to call script_unloaded hook #{hook}: #{e}")

--- a/lib/openhab/core/script_handling.rb
+++ b/lib/openhab/core/script_handling.rb
@@ -92,12 +92,7 @@ module OpenHAB
       #
       def scriptUnloaded # rubocop:disable Naming/MethodName method name dictated by openHAB
         logger.trace("Script unloaded")
-        ScriptHandlingCallbacks.script_unloaded_hooks
-                               .to_a
-                               .sort_by(&:first)
-                               .map(&:last)
-                               .flatten
-                               .each do |hook|
+        ScriptHandlingCallbacks.script_unloaded_hooks.sort_by(&:first).flat_map(&:last).each do |hook|
           hook.call
         rescue => e
           logger.error("Failed to call script_unloaded hook #{hook}: #{e}")

--- a/lib/openhab/core/things/provider.rb
+++ b/lib/openhab/core/things/provider.rb
@@ -19,6 +19,10 @@ module OpenHAB
             $things
           end
         end
+
+        def initialize
+          super(unload_priority: 60)
+        end
       end
     end
   end

--- a/lib/openhab/dsl/timer_manager.rb
+++ b/lib/openhab/dsl/timer_manager.rb
@@ -11,7 +11,7 @@ module OpenHAB
     class TimerManager
       include Singleton
 
-      Core::ScriptHandling.script_unloaded { instance.cancel_all }
+      Core::ScriptHandling.script_unloaded(priority: 40) { instance.cancel_all }
 
       # @!visibility private
       def initialize


### PR DESCRIPTION
This also gets around the [current issue encountered in jruby 9.4.1.0](https://github.com/jruby/jruby/issues/7637), because rules.build no longer calls the kwargs. Instead, the problem shifted to items.build / things.build.

At least the majority of scripts will work. Only scripts that used items.build / things.build will now be affected by the jruby 9.4.1.0 bug.